### PR TITLE
feat: QR provisioning + hot-swap node replacement

### DIFF
--- a/components/dp_gateway/CMakeLists.txt
+++ b/components/dp_gateway/CMakeLists.txt
@@ -3,9 +3,10 @@ idf_component_register(
         "dp_gateway.c"
         "dp_gateway_wifi.c"
         "dp_gateway_mqtt.c"
+        "dp_gateway_adopt.c"
     INCLUDE_DIRS "include"
-    REQUIRES dp_common
-    PRIV_REQUIRES log esp_event esp_netif esp_wifi mqtt json esp-tls
+    REQUIRES dp_common dp_mesh dp_prov
+    PRIV_REQUIRES log esp_event esp_netif esp_wifi mqtt json esp-tls mbedtls
 )
 
 if(CONFIG_DOCKPULSE_ROLE_GATEWAY AND

--- a/components/dp_gateway/dp_gateway.c
+++ b/components/dp_gateway/dp_gateway.c
@@ -12,6 +12,7 @@
 #include "esp_log.h"
 
 #include "dp_gateway_priv.h"
+#include "dp_prov.h"
 
 static const char *TAG = "dp_gateway";
 
@@ -27,18 +28,27 @@ static void now_iso8601(char *out, size_t cap)
     strftime(out, cap, "%Y-%m-%dT%H:%M:%SZ", &tm_utc);
 }
 
-// berth_id -> backend suffix (t1..t4, l1..l4, r1..r4). NULL if
-// out-of-range; caller should drop the publish, backend would reject
-// it as an unknown berth anyway
-static const char *berth_suffix(uint16_t idx)
+// Build a backend-format berth_id for the given mesh src addr. Tries
+// dp_prov first (set by adoption flow); falls back to legacy
+// CONFIG_DOCKPULSE_BERTH_ID_FORMAT + suffix table when no record
+// exists (bench testing without real adoption).
+static const char *const SUFFIXES[12] = {
+    "t1", "t2", "t3", "t4", "l1", "l2", "l3", "l4", "r1", "r2", "r3", "r4",
+};
+
+static bool render_berth_id(uint16_t src_addr, uint16_t fallback_idx, char *out, size_t cap)
 {
-    static const char *const SUFFIXES[12] = {
-        "t1", "t2", "t3", "t4", "l1", "l2", "l3", "l4", "r1", "r2", "r3", "r4",
-    };
-    if (idx >= 1 && idx <= 12) {
-        return SUFFIXES[idx - 1];
+    const char *mapped = dp_prov_lookup_berth(src_addr);
+    if (mapped && *mapped) {
+        strncpy(out, mapped, cap - 1);
+        out[cap - 1] = '\0';
+        return true;
     }
-    return NULL;
+    if (fallback_idx >= 1 && fallback_idx <= 12) {
+        snprintf(out, cap, CONFIG_DOCKPULSE_BERTH_ID_FORMAT, SUFFIXES[fallback_idx - 1]);
+        return true;
+    }
+    return false;
 }
 
 esp_err_t dp_gateway_init(void)
@@ -54,6 +64,7 @@ esp_err_t dp_gateway_init(void)
 #if CONFIG_DOCKPULSE_GATEWAY_UPLINK_STUB
     return ESP_OK;
 #else
+    dp_prov_init();
     esp_err_t err = dp_gateway_wifi_start_and_wait();
     if (err != ESP_OK) {
         return err;
@@ -61,6 +72,10 @@ esp_err_t dp_gateway_init(void)
     err = dp_gateway_mqtt_start_and_wait();
     if (err != ESP_OK) {
         return err;
+    }
+    err = dp_gateway_adopt_init();
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "adopt init err=%d (provisioning won't work)", err);
     }
 #if CONFIG_DOCKPULSE_MQTT_SELFTEST
     berth_status_t fake = {
@@ -86,16 +101,15 @@ esp_err_t dp_gateway_uplink(const berth_status_t *s, uint16_t src_addr)
              s->node_id, s->berth_id, s->occupied, s->sensor_raw_mm, (unsigned long)s->ts_ms);
     return ESP_OK;
 #else
-    const char *suffix = berth_suffix(s->berth_id);
-    if (!suffix) {
-        ESP_LOGW(TAG, "drop status, unknown berth_id=%u src=0x%04x", s->berth_id, src_addr);
-        return ESP_ERR_INVALID_ARG;
-    }
     char node_id[16];
     char berth_id[64];
     char ts_iso[32];
+    if (!render_berth_id(src_addr, s->berth_id, berth_id, sizeof(berth_id))) {
+        ESP_LOGW(TAG, "drop status, no berth mapping src=0x%04x payload_idx=%u", src_addr,
+                 s->berth_id);
+        return ESP_ERR_INVALID_ARG;
+    }
     snprintf(node_id, sizeof(node_id), "node-%03u", s->node_id);
-    snprintf(berth_id, sizeof(berth_id), CONFIG_DOCKPULSE_BERTH_ID_FORMAT, suffix);
     now_iso8601(ts_iso, sizeof(ts_iso));
 
     // Topic format per docs/api/mqtt-contract.yml in the dockpulse repo:
@@ -144,16 +158,15 @@ esp_err_t dp_gateway_uplink_diag(const berth_diag_t *d, uint16_t src_addr)
              src_addr, d->node_id, d->berth_id, d->target_state, d->raw_distance_cm);
     return ESP_OK;
 #else
-    const char *suffix = berth_suffix(d->berth_id);
-    if (!suffix) {
-        ESP_LOGW(TAG, "drop diag, unknown berth_id=%u src=0x%04x", d->berth_id, src_addr);
-        return ESP_ERR_INVALID_ARG;
-    }
     char node_id[16];
     char berth_id[64];
     char ts_iso[32];
+    if (!render_berth_id(src_addr, d->berth_id, berth_id, sizeof(berth_id))) {
+        ESP_LOGW(TAG, "drop diag, no berth mapping src=0x%04x payload_idx=%u", src_addr,
+                 d->berth_id);
+        return ESP_ERR_INVALID_ARG;
+    }
     snprintf(node_id, sizeof(node_id), "node-%03u", d->node_id);
-    snprintf(berth_id, sizeof(berth_id), CONFIG_DOCKPULSE_BERTH_ID_FORMAT, suffix);
     now_iso8601(ts_iso, sizeof(ts_iso));
 
     char topic[192];

--- a/components/dp_gateway/dp_gateway.c
+++ b/components/dp_gateway/dp_gateway.c
@@ -28,10 +28,8 @@ static void now_iso8601(char *out, size_t cap)
     strftime(out, cap, "%Y-%m-%dT%H:%M:%SZ", &tm_utc);
 }
 
-// Build a backend-format berth_id for the given mesh src addr. Tries
-// dp_prov first (set by adoption flow); falls back to legacy
-// CONFIG_DOCKPULSE_BERTH_ID_FORMAT + suffix table when no record
-// exists (bench testing without real adoption).
+// build berth_id from src_addr. dp_prov lookup first (adoption flow)
+// else BERTH_ID_FORMAT + suffix table (bench fallback)
 static const char *const SUFFIXES[12] = {
     "t1", "t2", "t3", "t4", "l1", "l2", "l3", "l4", "r1", "r2", "r3", "r4",
 };

--- a/components/dp_gateway/dp_gateway_adopt.c
+++ b/components/dp_gateway/dp_gateway_adopt.c
@@ -130,15 +130,12 @@ static void handle_provision_req(const char *payload, int len)
         ESP_LOGW(TAG, "bad json on provision/req");
         return;
     }
-    const char *req_id =
-        cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(root, "req_id"));
-    const char *uuid_hex =
-        cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(root, "uuid"));
+    const char *req_id = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(root, "req_id"));
+    const char *uuid_hex = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(root, "uuid"));
     const char *oob_hex = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(root, "oob"));
     cJSON *ttl_j = cJSON_GetObjectItemCaseSensitive(root, "ttl_s");
     // optional extension — backend may include the assigned berth
-    const char *berth =
-        cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(root, "berth_id"));
+    const char *berth = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(root, "berth_id"));
 
     if (!req_id || !uuid_hex) {
         ESP_LOGW(TAG, "missing req_id/uuid");
@@ -183,8 +180,8 @@ static void handle_provision_req(const char *payload, int len)
 
     ESP_LOGI(TAG, "req %s uuid=%02x%02x%02x... oob=%d berth=%s", s_inflight.req_id, uuid[0],
              uuid[1], uuid[2], have_oob ? 1 : 0, s_inflight.berth_id);
-    esp_err_t err = dp_mesh_gateway_provision(uuid, have_oob ? oob : NULL, timeout_ms,
-                                              on_prov_done, NULL);
+    esp_err_t err =
+        dp_mesh_gateway_provision(uuid, have_oob ? oob : NULL, timeout_ms, on_prov_done, NULL);
     if (err != ESP_OK) {
         publish_resp_err(s_inflight.req_id, "start-fail", esp_err_to_name(err));
         s_inflight.active = false;
@@ -206,8 +203,7 @@ esp_err_t dp_gateway_adopt_init(void)
 {
     dp_gateway_mqtt_set_msg_cb(on_msg);
     char topic[160];
-    snprintf(topic, sizeof(topic), "dockpulse/v1/gw/%s/provision/req",
-             CONFIG_DOCKPULSE_GATEWAY_ID);
+    snprintf(topic, sizeof(topic), "dockpulse/v1/gw/%s/provision/req", CONFIG_DOCKPULSE_GATEWAY_ID);
     return dp_gateway_mqtt_subscribe(topic, 1);
 }
 

--- a/components/dp_gateway/dp_gateway_adopt.c
+++ b/components/dp_gateway/dp_gateway_adopt.c
@@ -18,7 +18,7 @@ static const char *TAG = "dp_gw_adopt";
 
 #define DEFAULT_TTL_MS 60000
 
-// in-flight req — stack only handles one provision flow at a time
+// stack handles one provision flow at a time
 static struct {
     bool active;
     char req_id[64];
@@ -91,9 +91,8 @@ static void on_prov_done(const dp_mesh_prov_result_t *res, void *ctx)
         return;
     }
     if (res->ok) {
-        // record berth mapping if we have one (extension to backend
-        // protocol; if the req didn't carry berth_id, gateway falls
-        // back to addr-as-berth in uplink — see dp_gateway_uplink)
+        // record berth mapping if backend sent one. else uplink falls
+        // back to addr-as-berth (see dp_gateway_uplink)
         if (s_inflight.berth_id[0]) {
             dp_prov_record_berth(res->unicast_addr, s_inflight.berth_id);
         }
@@ -134,7 +133,7 @@ static void handle_provision_req(const char *payload, int len)
     const char *uuid_hex = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(root, "uuid"));
     const char *oob_hex = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(root, "oob"));
     cJSON *ttl_j = cJSON_GetObjectItemCaseSensitive(root, "ttl_s");
-    // optional extension — backend may include the assigned berth
+    // optional. backend may pass assigned berth
     const char *berth = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(root, "berth_id"));
 
     if (!req_id || !uuid_hex) {

--- a/components/dp_gateway/dp_gateway_adopt.c
+++ b/components/dp_gateway/dp_gateway_adopt.c
@@ -1,0 +1,214 @@
+#include "sdkconfig.h"
+
+#if CONFIG_DOCKPULSE_ROLE_GATEWAY && !CONFIG_DOCKPULSE_GATEWAY_UPLINK_STUB
+
+#include "dp_gateway_priv.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "cJSON.h"
+#include "esp_log.h"
+#include "mbedtls/sha256.h"
+
+#include "dp_mesh.h"
+#include "dp_prov.h"
+
+static const char *TAG = "dp_gw_adopt";
+
+#define DEFAULT_TTL_MS 60000
+
+// in-flight req — stack only handles one provision flow at a time
+static struct {
+    bool active;
+    char req_id[64];
+    char berth_id[DP_PROV_BERTH_ID_MAX];
+} s_inflight;
+
+static void publish_resp_ok(const char *req_id, uint16_t addr, const uint8_t dev_key[16])
+{
+    cJSON *root = cJSON_CreateObject();
+    if (!root) {
+        return;
+    }
+    cJSON_AddStringToObject(root, "req_id", req_id);
+    cJSON_AddStringToObject(root, "status", "ok");
+    char addr_str[8];
+    snprintf(addr_str, sizeof(addr_str), "0x%04x", addr);
+    cJSON_AddStringToObject(root, "unicast_addr", addr_str);
+    // dev_key fingerprint = first 8 bytes sha256(dev_key) hex-encoded
+    uint8_t hash[32];
+    mbedtls_sha256(dev_key, 16, hash, 0);
+    char fp[17];
+    for (int i = 0; i < 8; i++) {
+        snprintf(fp + i * 2, 3, "%02x", hash[i]);
+    }
+    fp[16] = '\0';
+    cJSON_AddStringToObject(root, "dev_key_fp", fp);
+
+    char *payload = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (!payload) {
+        return;
+    }
+    char topic[160];
+    snprintf(topic, sizeof(topic), "dockpulse/v1/gw/%s/provision/resp",
+             CONFIG_DOCKPULSE_GATEWAY_ID);
+    dp_gateway_mqtt_publish(topic, payload, 1);
+    ESP_LOGI(TAG, "resp ok req=%s addr=%s fp=%s", req_id, addr_str, fp);
+    cJSON_free(payload);
+}
+
+static void publish_resp_err(const char *req_id, const char *code, const char *msg)
+{
+    cJSON *root = cJSON_CreateObject();
+    if (!root) {
+        return;
+    }
+    cJSON_AddStringToObject(root, "req_id", req_id);
+    cJSON_AddStringToObject(root, "status", "err");
+    cJSON_AddStringToObject(root, "code", code ? code : "unknown");
+    if (msg) {
+        cJSON_AddStringToObject(root, "msg", msg);
+    }
+    char *payload = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (!payload) {
+        return;
+    }
+    char topic[160];
+    snprintf(topic, sizeof(topic), "dockpulse/v1/gw/%s/provision/resp",
+             CONFIG_DOCKPULSE_GATEWAY_ID);
+    dp_gateway_mqtt_publish(topic, payload, 1);
+    ESP_LOGW(TAG, "resp err req=%s code=%s msg=%s", req_id, code ? code : "?", msg ? msg : "");
+    cJSON_free(payload);
+}
+
+static void on_prov_done(const dp_mesh_prov_result_t *res, void *ctx)
+{
+    (void)ctx;
+    if (!s_inflight.active) {
+        return;
+    }
+    if (res->ok) {
+        // record berth mapping if we have one (extension to backend
+        // protocol; if the req didn't carry berth_id, gateway falls
+        // back to addr-as-berth in uplink — see dp_gateway_uplink)
+        if (s_inflight.berth_id[0]) {
+            dp_prov_record_berth(res->unicast_addr, s_inflight.berth_id);
+        }
+        publish_resp_ok(s_inflight.req_id, res->unicast_addr, res->dev_key);
+    } else {
+        publish_resp_err(s_inflight.req_id, res->err_code, res->err_msg);
+    }
+    s_inflight.active = false;
+    s_inflight.req_id[0] = '\0';
+    s_inflight.berth_id[0] = '\0';
+}
+
+// hex string -> bytes; returns ESP_OK iff exactly 2*expected_bytes hex chars
+static esp_err_t hex_decode(const char *hex, uint8_t *out, size_t expected_bytes)
+{
+    size_t hlen = strlen(hex);
+    if (hlen != expected_bytes * 2) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+    for (size_t i = 0; i < expected_bytes; i++) {
+        unsigned int v;
+        if (sscanf(hex + i * 2, "%2x", &v) != 1) {
+            return ESP_ERR_INVALID_ARG;
+        }
+        out[i] = (uint8_t)v;
+    }
+    return ESP_OK;
+}
+
+static void handle_provision_req(const char *payload, int len)
+{
+    cJSON *root = cJSON_ParseWithLength(payload, len);
+    if (!root) {
+        ESP_LOGW(TAG, "bad json on provision/req");
+        return;
+    }
+    const char *req_id =
+        cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(root, "req_id"));
+    const char *uuid_hex =
+        cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(root, "uuid"));
+    const char *oob_hex = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(root, "oob"));
+    cJSON *ttl_j = cJSON_GetObjectItemCaseSensitive(root, "ttl_s");
+    // optional extension — backend may include the assigned berth
+    const char *berth =
+        cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(root, "berth_id"));
+
+    if (!req_id || !uuid_hex) {
+        ESP_LOGW(TAG, "missing req_id/uuid");
+        cJSON_Delete(root);
+        return;
+    }
+    if (s_inflight.active) {
+        publish_resp_err(req_id, "busy", NULL);
+        cJSON_Delete(root);
+        return;
+    }
+    uint8_t uuid[16];
+    if (hex_decode(uuid_hex, uuid, 16) != ESP_OK) {
+        publish_resp_err(req_id, "bad-uuid", NULL);
+        cJSON_Delete(root);
+        return;
+    }
+    uint8_t oob[16] = {0};
+    bool have_oob = false;
+    if (oob_hex && *oob_hex) {
+        if (hex_decode(oob_hex, oob, 16) != ESP_OK) {
+            publish_resp_err(req_id, "bad-oob", NULL);
+            cJSON_Delete(root);
+            return;
+        }
+        have_oob = true;
+    }
+    uint32_t timeout_ms = DEFAULT_TTL_MS;
+    if (cJSON_IsNumber(ttl_j) && ttl_j->valueint > 0) {
+        timeout_ms = (uint32_t)ttl_j->valueint * 1000U;
+    }
+
+    s_inflight.active = true;
+    strncpy(s_inflight.req_id, req_id, sizeof(s_inflight.req_id) - 1);
+    s_inflight.req_id[sizeof(s_inflight.req_id) - 1] = '\0';
+    s_inflight.berth_id[0] = '\0';
+    if (berth && *berth) {
+        strncpy(s_inflight.berth_id, berth, sizeof(s_inflight.berth_id) - 1);
+        s_inflight.berth_id[sizeof(s_inflight.berth_id) - 1] = '\0';
+    }
+    cJSON_Delete(root);
+
+    ESP_LOGI(TAG, "req %s uuid=%02x%02x%02x... oob=%d berth=%s", s_inflight.req_id, uuid[0],
+             uuid[1], uuid[2], have_oob ? 1 : 0, s_inflight.berth_id);
+    esp_err_t err = dp_mesh_gateway_provision(uuid, have_oob ? oob : NULL, timeout_ms,
+                                              on_prov_done, NULL);
+    if (err != ESP_OK) {
+        publish_resp_err(s_inflight.req_id, "start-fail", esp_err_to_name(err));
+        s_inflight.active = false;
+        s_inflight.req_id[0] = '\0';
+    }
+}
+
+static void on_msg(const char *topic, const char *payload, int len)
+{
+    char expect[160];
+    snprintf(expect, sizeof(expect), "dockpulse/v1/gw/%s/provision/req",
+             CONFIG_DOCKPULSE_GATEWAY_ID);
+    if (strcmp(topic, expect) == 0) {
+        handle_provision_req(payload, len);
+    }
+}
+
+esp_err_t dp_gateway_adopt_init(void)
+{
+    dp_gateway_mqtt_set_msg_cb(on_msg);
+    char topic[160];
+    snprintf(topic, sizeof(topic), "dockpulse/v1/gw/%s/provision/req",
+             CONFIG_DOCKPULSE_GATEWAY_ID);
+    return dp_gateway_mqtt_subscribe(topic, 1);
+}
+
+#endif

--- a/components/dp_gateway/dp_gateway_mqtt.c
+++ b/components/dp_gateway/dp_gateway_mqtt.c
@@ -21,7 +21,7 @@ extern const char client_key_start[] asm("_binary_client_key_start");
 
 static const char *TAG = "dp_gw_mqtt";
 
-#define MQTT_CONNECTED_BIT BIT0
+#define MQTT_CONNECTED_BIT  BIT0
 #define DP_MAX_PENDING_SUBS 4
 
 static esp_mqtt_client_handle_t s_client;
@@ -40,8 +40,8 @@ static void apply_pending_subs(void)
 {
     for (int i = 0; i < DP_MAX_PENDING_SUBS; i++) {
         if (s_pending_subs[i].active) {
-            int mid = esp_mqtt_client_subscribe(s_client, s_pending_subs[i].topic,
-                                                s_pending_subs[i].qos);
+            int mid =
+                esp_mqtt_client_subscribe(s_client, s_pending_subs[i].topic, s_pending_subs[i].qos);
             ESP_LOGI(TAG, "subscribe %s qos=%d mid=%d", s_pending_subs[i].topic,
                      s_pending_subs[i].qos, mid);
         }

--- a/components/dp_gateway/dp_gateway_mqtt.c
+++ b/components/dp_gateway/dp_gateway_mqtt.c
@@ -5,6 +5,8 @@
 #include "dp_gateway_priv.h"
 
 #include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
 
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
@@ -20,9 +22,43 @@ extern const char client_key_start[] asm("_binary_client_key_start");
 static const char *TAG = "dp_gw_mqtt";
 
 #define MQTT_CONNECTED_BIT BIT0
+#define DP_MAX_PENDING_SUBS 4
 
 static esp_mqtt_client_handle_t s_client;
 static EventGroupHandle_t s_mqtt_events;
+static dp_gateway_mqtt_msg_cb_t s_msg_cb;
+
+// queued subs registered before broker connects (or before s_client init)
+typedef struct {
+    char topic[96];
+    int qos;
+    bool active;
+} pending_sub_t;
+static pending_sub_t s_pending_subs[DP_MAX_PENDING_SUBS];
+
+static void apply_pending_subs(void)
+{
+    for (int i = 0; i < DP_MAX_PENDING_SUBS; i++) {
+        if (s_pending_subs[i].active) {
+            int mid = esp_mqtt_client_subscribe(s_client, s_pending_subs[i].topic,
+                                                s_pending_subs[i].qos);
+            ESP_LOGI(TAG, "subscribe %s qos=%d mid=%d", s_pending_subs[i].topic,
+                     s_pending_subs[i].qos, mid);
+        }
+    }
+}
+
+// LWT topic + payload kept around for client lifetime — esp_mqtt_client
+// stores by reference, not copy
+static char s_lwt_topic[160];
+static const char LWT_PAYLOAD[] = "{\"online\":false}";
+
+static void publish_online_retained(void)
+{
+    if (s_lwt_topic[0]) {
+        esp_mqtt_client_publish(s_client, s_lwt_topic, "{\"online\":true}", 0, 1, 1);
+    }
+}
 
 static void on_mqtt_event(void *arg, esp_event_base_t base, int32_t id, void *data)
 {
@@ -33,24 +69,63 @@ static void on_mqtt_event(void *arg, esp_event_base_t base, int32_t id, void *da
     case MQTT_EVENT_CONNECTED:
         ESP_LOGI(TAG, "broker connected");
         xEventGroupSetBits(s_mqtt_events, MQTT_CONNECTED_BIT);
+        apply_pending_subs();
+        publish_online_retained();
         break;
     case MQTT_EVENT_DISCONNECTED:
         ESP_LOGW(TAG, "broker disconnected");
         xEventGroupClearBits(s_mqtt_events, MQTT_CONNECTED_BIT);
         break;
+    case MQTT_EVENT_DATA:
+        if (s_msg_cb && event && event->topic && event->data) {
+            // event->topic is NOT null-terminated; copy out
+            char topic[160];
+            int tlen = event->topic_len < (int)sizeof(topic) - 1 ? event->topic_len
+                                                                 : (int)sizeof(topic) - 1;
+            memcpy(topic, event->topic, tlen);
+            topic[tlen] = '\0';
+            s_msg_cb(topic, event->data, event->data_len);
+        }
+        break;
     case MQTT_EVENT_ERROR:
         if (event && event->error_handle) {
-            ESP_LOGE(TAG, "broker error: type=%d tls_err=0x%x tls_stack_err=0x%x sock_errno=%d",
+            ESP_LOGE(TAG, "broker error: type=%d tls=0x%x stack=0x%x sock=%d",
                      event->error_handle->error_type, event->error_handle->esp_tls_last_esp_err,
                      event->error_handle->esp_tls_stack_err,
                      event->error_handle->esp_transport_sock_errno);
-        } else {
-            ESP_LOGE(TAG, "broker error");
         }
         break;
     default:
         break;
     }
+}
+
+esp_err_t dp_gateway_mqtt_set_msg_cb(dp_gateway_mqtt_msg_cb_t cb)
+{
+    s_msg_cb = cb;
+    return ESP_OK;
+}
+
+esp_err_t dp_gateway_mqtt_subscribe(const char *topic_filter, int qos)
+{
+    if (!topic_filter) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    for (int i = 0; i < DP_MAX_PENDING_SUBS; i++) {
+        if (!s_pending_subs[i].active) {
+            strncpy(s_pending_subs[i].topic, topic_filter, sizeof(s_pending_subs[i].topic) - 1);
+            s_pending_subs[i].qos = qos;
+            s_pending_subs[i].active = true;
+            // if already connected, register now too
+            if (s_client && s_mqtt_events &&
+                (xEventGroupGetBits(s_mqtt_events) & MQTT_CONNECTED_BIT)) {
+                int mid = esp_mqtt_client_subscribe(s_client, topic_filter, qos);
+                ESP_LOGI(TAG, "subscribe %s qos=%d mid=%d", topic_filter, qos, mid);
+            }
+            return ESP_OK;
+        }
+    }
+    return ESP_ERR_NO_MEM;
 }
 
 esp_err_t dp_gateway_mqtt_start_and_wait(void)
@@ -60,8 +135,17 @@ esp_err_t dp_gateway_mqtt_start_and_wait(void)
         return ESP_ERR_NO_MEM;
     }
 
+    // LWT topic uses the configured gateway id
+    snprintf(s_lwt_topic, sizeof(s_lwt_topic), "dockpulse/v1/gw/%s/status",
+             CONFIG_DOCKPULSE_GATEWAY_ID);
+
     esp_mqtt_client_config_t cfg = {
         .broker.address.uri = CONFIG_DOCKPULSE_MQTT_BROKER_URI,
+        .session.last_will.topic = s_lwt_topic,
+        .session.last_will.msg = LWT_PAYLOAD,
+        .session.last_will.msg_len = (int)(sizeof(LWT_PAYLOAD) - 1),
+        .session.last_will.qos = 1,
+        .session.last_will.retain = 1,
     };
     if (CONFIG_DOCKPULSE_MQTT_CLIENT_ID[0] != '\0') {
         cfg.credentials.client_id = CONFIG_DOCKPULSE_MQTT_CLIENT_ID;
@@ -90,25 +174,31 @@ esp_err_t dp_gateway_mqtt_start_and_wait(void)
     return ESP_OK;
 }
 
-esp_err_t dp_gateway_mqtt_publish(const char *topic, const char *payload, int qos)
+static esp_err_t publish(const char *topic, const char *payload, int qos, bool retain)
 {
     if (!s_client || !topic || !payload) {
         return ESP_ERR_INVALID_ARG;
     }
     EventBits_t bits = xEventGroupGetBits(s_mqtt_events);
     if (!(bits & MQTT_CONNECTED_BIT)) {
-        // log every 16th drop so a lost broker doesn't spam
         static uint32_t s_dropped;
         if ((s_dropped++ & 0x0F) == 0) {
             ESP_LOGW(TAG, "drop publish, broker disconnected (total=%" PRIu32 ")", s_dropped);
         }
         return ESP_ERR_INVALID_STATE;
     }
-    int msg_id = esp_mqtt_client_publish(s_client, topic, payload, 0, qos, 0);
-    if (msg_id < 0) {
-        return ESP_FAIL;
-    }
-    return ESP_OK;
+    int msg_id = esp_mqtt_client_publish(s_client, topic, payload, 0, qos, retain ? 1 : 0);
+    return msg_id < 0 ? ESP_FAIL : ESP_OK;
+}
+
+esp_err_t dp_gateway_mqtt_publish(const char *topic, const char *payload, int qos)
+{
+    return publish(topic, payload, qos, false);
+}
+
+esp_err_t dp_gateway_mqtt_publish_retained(const char *topic, const char *payload, int qos)
+{
+    return publish(topic, payload, qos, true);
 }
 
 #endif

--- a/components/dp_gateway/dp_gateway_mqtt.c
+++ b/components/dp_gateway/dp_gateway_mqtt.c
@@ -48,8 +48,7 @@ static void apply_pending_subs(void)
     }
 }
 
-// LWT topic + payload kept around for client lifetime — esp_mqtt_client
-// stores by reference, not copy
+// LWT topic + payload live for client lifetime. esp_mqtt_client stores by ref
 static char s_lwt_topic[160];
 static const char LWT_PAYLOAD[] = "{\"online\":false}";
 

--- a/components/dp_gateway/dp_gateway_priv.h
+++ b/components/dp_gateway/dp_gateway_priv.h
@@ -11,8 +11,21 @@ extern "C" {
 
 esp_err_t dp_gateway_wifi_start_and_wait(void);
 
+// MQTT message dispatch — set before start_and_wait so subscription
+// callbacks have somewhere to land on first connect
+typedef void (*dp_gateway_mqtt_msg_cb_t)(const char *topic, const char *payload, int payload_len);
+
+esp_err_t dp_gateway_mqtt_set_msg_cb(dp_gateway_mqtt_msg_cb_t cb);
+esp_err_t dp_gateway_mqtt_subscribe(const char *topic_filter, int qos);
 esp_err_t dp_gateway_mqtt_start_and_wait(void);
 esp_err_t dp_gateway_mqtt_publish(const char *topic, const char *payload, int qos);
+esp_err_t dp_gateway_mqtt_publish_retained(const char *topic, const char *payload, int qos);
+
+// Adoption: subscribes to dockpulse/v1/gw/{gw_id}/provision/req, runs
+// PB-ADV via dp_mesh, replies on dockpulse/v1/gw/{gw_id}/provision/resp,
+// publishes retained {online:true} on dockpulse/v1/gw/{gw_id}/status
+// (LWT publishes {online:false} on disconnect)
+esp_err_t dp_gateway_adopt_init(void);
 
 #ifdef __cplusplus
 }

--- a/components/dp_gateway/dp_gateway_priv.h
+++ b/components/dp_gateway/dp_gateway_priv.h
@@ -11,8 +11,7 @@ extern "C" {
 
 esp_err_t dp_gateway_wifi_start_and_wait(void);
 
-// MQTT message dispatch — set before start_and_wait so subscription
-// callbacks have somewhere to land on first connect
+// set before start_and_wait so first-connect subs have a landing pad
 typedef void (*dp_gateway_mqtt_msg_cb_t)(const char *topic, const char *payload, int payload_len);
 
 esp_err_t dp_gateway_mqtt_set_msg_cb(dp_gateway_mqtt_msg_cb_t cb);
@@ -21,10 +20,8 @@ esp_err_t dp_gateway_mqtt_start_and_wait(void);
 esp_err_t dp_gateway_mqtt_publish(const char *topic, const char *payload, int qos);
 esp_err_t dp_gateway_mqtt_publish_retained(const char *topic, const char *payload, int qos);
 
-// Adoption: subscribes to dockpulse/v1/gw/{gw_id}/provision/req, runs
-// PB-ADV via dp_mesh, replies on dockpulse/v1/gw/{gw_id}/provision/resp,
-// publishes retained {online:true} on dockpulse/v1/gw/{gw_id}/status
-// (LWT publishes {online:false} on disconnect)
+// adoption: subs provision/req runs PB-ADV via dp_mesh replies provision/resp.
+// retained {online:true} on /status. LWT {online:false} on disconnect
 esp_err_t dp_gateway_adopt_init(void);
 
 #ifdef __cplusplus

--- a/components/dp_io/CMakeLists.txt
+++ b/components/dp_io/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "dp_io.c"
     INCLUDE_DIRS "include"
-    REQUIRES driver
+    REQUIRES driver esp_driver_rmt
 )

--- a/components/dp_io/CMakeLists.txt
+++ b/components/dp_io/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "dp_io.c"
+    INCLUDE_DIRS "include"
+    REQUIRES driver
+)

--- a/components/dp_io/dp_io.c
+++ b/components/dp_io/dp_io.c
@@ -28,26 +28,29 @@ static void *s_btn_ctx;
 // c3-zero LED is RGB-native led_strip 2.5.x only ships GRB so swap r/g here
 static inline void led_rgb(uint8_t r, uint8_t g, uint8_t b)
 {
-    if (!s_strip) return;
+    if (!s_strip)
+        return;
     led_strip_set_pixel(s_strip, 0, g, r, b);
     led_strip_refresh(s_strip);
 }
-#define LED_OFF()         led_rgb(0, 0, 0)
-#define LED_OK_COLOR()    led_rgb(0, 12, 0)     // dim green
-#define LED_PROV_COLOR()  led_rgb(0, 0, 24)     // medium blue
-#define LED_ERR_COLOR()   led_rgb(24, 0, 0)     // red
+#define LED_OFF()        led_rgb(0, 0, 0)
+#define LED_OK_COLOR()   led_rgb(0, 12, 0) // dim green
+#define LED_PROV_COLOR() led_rgb(0, 0, 24) // medium blue
+#define LED_ERR_COLOR()  led_rgb(24, 0, 0) // red
 #else
 static inline void led_drive(bool on)
 {
-    if (s_led_gpio < 0) return;
+    if (s_led_gpio < 0)
+        return;
     int level = on ? 1 : 0;
-    if (s_led_active_low) level = !level;
+    if (s_led_active_low)
+        level = !level;
     gpio_set_level((gpio_num_t)s_led_gpio, level);
 }
-#define LED_OFF()         led_drive(false)
-#define LED_OK_COLOR()    led_drive(true)
-#define LED_PROV_COLOR()  led_drive(true)
-#define LED_ERR_COLOR()   led_drive(true)
+#define LED_OFF()        led_drive(false)
+#define LED_OK_COLOR()   led_drive(true)
+#define LED_PROV_COLOR() led_drive(true)
+#define LED_ERR_COLOR()  led_drive(true)
 #endif
 
 static void led_task(void *arg)
@@ -73,7 +76,10 @@ static void led_task(void *arg)
         case DP_LED_PROVISIONING:
             // 4Hz easy to spot scanning QR
             on = !on;
-            if (on) LED_PROV_COLOR(); else LED_OFF();
+            if (on)
+                LED_PROV_COLOR();
+            else
+                LED_OFF();
             vTaskDelay(pdMS_TO_TICKS(125));
             break;
         case DP_LED_ERROR:
@@ -128,7 +134,8 @@ esp_err_t dp_led_init(void)
         .intr_type = GPIO_INTR_DISABLE,
     };
     esp_err_t err = gpio_config(&io);
-    if (err != ESP_OK) return err;
+    if (err != ESP_OK)
+        return err;
     led_drive(false);
 #endif
 

--- a/components/dp_io/dp_io.c
+++ b/components/dp_io/dp_io.c
@@ -6,26 +6,49 @@
 #include "freertos/task.h"
 #include "sdkconfig.h"
 
+#if CONFIG_DOCKPULSE_LED_WS2812
+#include "led_strip.h"
+#endif
+
 static const char *TAG = "dp_io";
 
 static volatile dp_led_state_t s_led_state = DP_LED_OFF;
 static int s_led_gpio = -1;
+
+#if CONFIG_DOCKPULSE_LED_WS2812
+static led_strip_handle_t s_strip;
+#else
 static bool s_led_active_low;
+#endif
 
 static dp_button_long_press_cb_t s_btn_cb;
 static void *s_btn_ctx;
 
+#if CONFIG_DOCKPULSE_LED_WS2812
+// c3-zero LED is RGB-native led_strip 2.5.x only ships GRB so swap r/g here
+static inline void led_rgb(uint8_t r, uint8_t g, uint8_t b)
+{
+    if (!s_strip) return;
+    led_strip_set_pixel(s_strip, 0, g, r, b);
+    led_strip_refresh(s_strip);
+}
+#define LED_OFF()         led_rgb(0, 0, 0)
+#define LED_OK_COLOR()    led_rgb(0, 12, 0)     // dim green
+#define LED_PROV_COLOR()  led_rgb(0, 0, 24)     // medium blue
+#define LED_ERR_COLOR()   led_rgb(24, 0, 0)     // red
+#else
 static inline void led_drive(bool on)
 {
-    if (s_led_gpio < 0) {
-        return;
-    }
+    if (s_led_gpio < 0) return;
     int level = on ? 1 : 0;
-    if (s_led_active_low) {
-        level = !level;
-    }
+    if (s_led_active_low) level = !level;
     gpio_set_level((gpio_num_t)s_led_gpio, level);
 }
+#define LED_OFF()         led_drive(false)
+#define LED_OK_COLOR()    led_drive(true)
+#define LED_PROV_COLOR()  led_drive(true)
+#define LED_ERR_COLOR()   led_drive(true)
+#endif
 
 static void led_task(void *arg)
 {
@@ -34,33 +57,33 @@ static void led_task(void *arg)
     while (true) {
         switch (s_led_state) {
         case DP_LED_OFF:
-            led_drive(false);
+            LED_OFF();
             vTaskDelay(pdMS_TO_TICKS(200));
             break;
         case DP_LED_OK:
-            led_drive(true);
+            LED_OK_COLOR();
             vTaskDelay(pdMS_TO_TICKS(500));
             break;
         case DP_LED_IDLE:
-            led_drive(true);
+            LED_OK_COLOR();
             vTaskDelay(pdMS_TO_TICKS(100));
-            led_drive(false);
+            LED_OFF();
             vTaskDelay(pdMS_TO_TICKS(900));
             break;
         case DP_LED_PROVISIONING:
-            // 4Hz — easy to spot at arm's length while scanning QR
+            // 4Hz easy to spot scanning QR
             on = !on;
-            led_drive(on);
+            if (on) LED_PROV_COLOR(); else LED_OFF();
             vTaskDelay(pdMS_TO_TICKS(125));
             break;
         case DP_LED_ERROR:
-            led_drive(true);
+            LED_ERR_COLOR();
             vTaskDelay(pdMS_TO_TICKS(80));
-            led_drive(false);
+            LED_OFF();
             vTaskDelay(pdMS_TO_TICKS(120));
-            led_drive(true);
+            LED_ERR_COLOR();
             vTaskDelay(pdMS_TO_TICKS(80));
-            led_drive(false);
+            LED_OFF();
             vTaskDelay(pdMS_TO_TICKS(1720));
             break;
         }
@@ -70,11 +93,33 @@ static void led_task(void *arg)
 esp_err_t dp_led_init(void)
 {
     s_led_gpio = CONFIG_DOCKPULSE_LED_GPIO;
-    s_led_active_low = CONFIG_DOCKPULSE_LED_ACTIVE_LOW;
     if (s_led_gpio < 0) {
         ESP_LOGI(TAG, "LED disabled");
         return ESP_OK;
     }
+
+#if CONFIG_DOCKPULSE_LED_WS2812
+    led_strip_config_t strip_cfg = {
+        .strip_gpio_num = s_led_gpio,
+        .max_leds = 1,
+        .led_pixel_format = LED_PIXEL_FORMAT_GRB,
+        .led_model = LED_MODEL_WS2812,
+        .flags = {.invert_out = false},
+    };
+    led_strip_rmt_config_t rmt_cfg = {
+        .clk_src = RMT_CLK_SRC_DEFAULT,
+        .resolution_hz = 10 * 1000 * 1000,
+        .mem_block_symbols = 64,
+        .flags = {.with_dma = false},
+    };
+    esp_err_t err = led_strip_new_rmt_device(&strip_cfg, &rmt_cfg, &s_strip);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "led_strip new err=%d", err);
+        return err;
+    }
+    led_strip_clear(s_strip);
+#else
+    s_led_active_low = CONFIG_DOCKPULSE_LED_ACTIVE_LOW;
     gpio_config_t io = {
         .pin_bit_mask = 1ULL << s_led_gpio,
         .mode = GPIO_MODE_OUTPUT,
@@ -83,11 +128,11 @@ esp_err_t dp_led_init(void)
         .intr_type = GPIO_INTR_DISABLE,
     };
     esp_err_t err = gpio_config(&io);
-    if (err != ESP_OK) {
-        return err;
-    }
+    if (err != ESP_OK) return err;
     led_drive(false);
-    BaseType_t ok = xTaskCreate(led_task, "dp_led", 2048, NULL, 4, NULL);
+#endif
+
+    BaseType_t ok = xTaskCreate(led_task, "dp_led", 2560, NULL, 4, NULL);
     return ok == pdPASS ? ESP_OK : ESP_ERR_NO_MEM;
 }
 

--- a/components/dp_io/dp_io.c
+++ b/components/dp_io/dp_io.c
@@ -1,0 +1,146 @@
+#include "dp_io.h"
+
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "sdkconfig.h"
+
+static const char *TAG = "dp_io";
+
+static volatile dp_led_state_t s_led_state = DP_LED_OFF;
+static int s_led_gpio = -1;
+static bool s_led_active_low;
+
+static dp_button_long_press_cb_t s_btn_cb;
+static void *s_btn_ctx;
+
+static inline void led_drive(bool on)
+{
+    if (s_led_gpio < 0) {
+        return;
+    }
+    int level = on ? 1 : 0;
+    if (s_led_active_low) {
+        level = !level;
+    }
+    gpio_set_level((gpio_num_t)s_led_gpio, level);
+}
+
+static void led_task(void *arg)
+{
+    (void)arg;
+    bool on = false;
+    while (true) {
+        switch (s_led_state) {
+        case DP_LED_OFF:
+            led_drive(false);
+            vTaskDelay(pdMS_TO_TICKS(200));
+            break;
+        case DP_LED_OK:
+            led_drive(true);
+            vTaskDelay(pdMS_TO_TICKS(500));
+            break;
+        case DP_LED_IDLE:
+            led_drive(true);
+            vTaskDelay(pdMS_TO_TICKS(100));
+            led_drive(false);
+            vTaskDelay(pdMS_TO_TICKS(900));
+            break;
+        case DP_LED_PROVISIONING:
+            // 4Hz — easy to spot at arm's length while scanning QR
+            on = !on;
+            led_drive(on);
+            vTaskDelay(pdMS_TO_TICKS(125));
+            break;
+        case DP_LED_ERROR:
+            led_drive(true);
+            vTaskDelay(pdMS_TO_TICKS(80));
+            led_drive(false);
+            vTaskDelay(pdMS_TO_TICKS(120));
+            led_drive(true);
+            vTaskDelay(pdMS_TO_TICKS(80));
+            led_drive(false);
+            vTaskDelay(pdMS_TO_TICKS(1720));
+            break;
+        }
+    }
+}
+
+esp_err_t dp_led_init(void)
+{
+    s_led_gpio = CONFIG_DOCKPULSE_LED_GPIO;
+    s_led_active_low = CONFIG_DOCKPULSE_LED_ACTIVE_LOW;
+    if (s_led_gpio < 0) {
+        ESP_LOGI(TAG, "LED disabled");
+        return ESP_OK;
+    }
+    gpio_config_t io = {
+        .pin_bit_mask = 1ULL << s_led_gpio,
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    esp_err_t err = gpio_config(&io);
+    if (err != ESP_OK) {
+        return err;
+    }
+    led_drive(false);
+    BaseType_t ok = xTaskCreate(led_task, "dp_led", 2048, NULL, 4, NULL);
+    return ok == pdPASS ? ESP_OK : ESP_ERR_NO_MEM;
+}
+
+void dp_led_set(dp_led_state_t state) { s_led_state = state; }
+
+// Poll instead of ISR — GPIO 9 is also the C3 boot strap; ISR EDGE
+// races with whatever the boot ROM left. Poll loop debounces for free.
+static void button_task(void *arg)
+{
+    (void)arg;
+    const int gpio = CONFIG_DOCKPULSE_FACTORY_RESET_GPIO;
+    const int hold_ms = CONFIG_DOCKPULSE_FACTORY_RESET_HOLD_MS;
+    const TickType_t poll = pdMS_TO_TICKS(50);
+    int held_ms = 0;
+    while (true) {
+        if (gpio_get_level((gpio_num_t)gpio) == 0) {
+            held_ms += 50;
+            if (held_ms >= hold_ms) {
+                ESP_LOGW(TAG, "factory-reset held %dms — firing cb", held_ms);
+                if (s_btn_cb) {
+                    s_btn_cb(s_btn_ctx);
+                }
+                while (true) {
+                    vTaskDelay(pdMS_TO_TICKS(1000));
+                }
+            }
+        } else {
+            held_ms = 0;
+        }
+        vTaskDelay(poll);
+    }
+}
+
+esp_err_t dp_button_init(dp_button_long_press_cb_t cb, void *user_ctx)
+{
+    s_btn_cb = cb;
+    s_btn_ctx = user_ctx;
+    int gpio = CONFIG_DOCKPULSE_FACTORY_RESET_GPIO;
+    if (gpio < 0) {
+        ESP_LOGI(TAG, "factory-reset disabled");
+        return ESP_OK;
+    }
+    gpio_config_t io = {
+        .pin_bit_mask = 1ULL << gpio,
+        .mode = GPIO_MODE_INPUT,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    esp_err_t err = gpio_config(&io);
+    if (err != ESP_OK) {
+        return err;
+    }
+    BaseType_t ok = xTaskCreate(button_task, "dp_btn", 2048, NULL, 4, NULL);
+    return ok == pdPASS ? ESP_OK : ESP_ERR_NO_MEM;
+}

--- a/components/dp_io/dp_io.c
+++ b/components/dp_io/dp_io.c
@@ -138,8 +138,8 @@ esp_err_t dp_led_init(void)
 
 void dp_led_set(dp_led_state_t state) { s_led_state = state; }
 
-// Poll instead of ISR — GPIO 9 is also the C3 boot strap; ISR EDGE
-// races with whatever the boot ROM left. Poll loop debounces for free.
+// poll not ISR. gpio 9 is c3 boot strap so ISR edge races boot ROM.
+// poll loop debounces for free
 static void button_task(void *arg)
 {
     (void)arg;

--- a/components/dp_io/idf_component.yml
+++ b/components/dp_io/idf_component.yml
@@ -1,0 +1,5 @@
+## https://components.espressif.com/components/espressif/led_strip
+dependencies:
+  idf:
+    version: ">=5.3"
+  espressif/led_strip: "^2.5"

--- a/components/dp_io/include/dp_io.h
+++ b/components/dp_io/include/dp_io.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    DP_LED_OFF,
+    DP_LED_OK,           // solid: provisioned + uplink OK
+    DP_LED_IDLE,         // slow heartbeat: provisioned, no recent uplink
+    DP_LED_PROVISIONING, // fast blink: PB-ADV unprovisioned beacon
+    DP_LED_ERROR,        // double flash: disconnected
+} dp_led_state_t;
+
+esp_err_t dp_led_init(void);
+void dp_led_set(dp_led_state_t state);
+
+// Long-press cb runs in dedicated task. Typical impl: dp_prov_factory_reset().
+typedef void (*dp_button_long_press_cb_t)(void *user_ctx);
+esp_err_t dp_button_init(dp_button_long_press_cb_t cb, void *user_ctx);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/dp_mesh/CMakeLists.txt
+++ b/components/dp_mesh/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "dp_mesh.c"
     INCLUDE_DIRS "include"
-    REQUIRES dp_common bt nvs_flash esp_hw_support mbedtls
+    REQUIRES dp_common dp_prov bt nvs_flash esp_hw_support esp_timer mbedtls
 )

--- a/components/dp_mesh/dp_mesh.c
+++ b/components/dp_mesh/dp_mesh.c
@@ -674,11 +674,11 @@ esp_err_t dp_mesh_init(const dp_mesh_cfg_t *cfg)
     }
 
     // log UUID hex for sim-adopt copy-paste
-    ESP_LOGI(TAG, "ready role=%s uuid=%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
-             s_role == DP_MESH_ROLE_GATEWAY ? "gateway" : "sensor",
-             s_dev_uuid[0], s_dev_uuid[1], s_dev_uuid[2], s_dev_uuid[3],
-             s_dev_uuid[4], s_dev_uuid[5], s_dev_uuid[6], s_dev_uuid[7],
-             s_dev_uuid[8], s_dev_uuid[9], s_dev_uuid[10], s_dev_uuid[11],
+    ESP_LOGI(TAG,
+             "ready role=%s uuid=%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+             s_role == DP_MESH_ROLE_GATEWAY ? "gateway" : "sensor", s_dev_uuid[0], s_dev_uuid[1],
+             s_dev_uuid[2], s_dev_uuid[3], s_dev_uuid[4], s_dev_uuid[5], s_dev_uuid[6],
+             s_dev_uuid[7], s_dev_uuid[8], s_dev_uuid[9], s_dev_uuid[10], s_dev_uuid[11],
              s_dev_uuid[12], s_dev_uuid[13], s_dev_uuid[14], s_dev_uuid[15]);
     return ESP_OK;
 }

--- a/components/dp_mesh/dp_mesh.c
+++ b/components/dp_mesh/dp_mesh.c
@@ -1,17 +1,9 @@
-// BLE Mesh wrapper using esp_ble_mesh on NimBLE host. (NimBLE-mesh is
-// broken: per-buffer adv events never get ble_npl_event_init'd, legacy
-// adv worker is gated #ifdef MYNEWT, IDF blemesh example doesn't
-// exercise pub/sub.)
+// esp_ble_mesh on NimBLE host. NimBLE-mesh is broken (per-buffer adv
+// events never ble_npl_event_init'd legacy adv worker gated #ifdef MYNEWT)
 //
-// Topology: hub-and-spoke. Sensor=NODE, gateway=PROVISIONER. Real
-// PB-ADV: sensor advertises unprov beacon on first boot, gateway
-// provisions on demand from MQTT request, then binds AppKey + sets
-// publication via cfg client. Subsequent boots restore from NVS via
-// CONFIG_BLE_MESH_SETTINGS=y.
-//
-// Earlier self-provisioning hack (both sides as provisioners with
-// shared keys + phantom-peer registration) is gone — see git for the
-// archaeology.
+// hub-and-spoke topology. sensor=NODE gateway=PROVISIONER. real PB-ADV
+// kicked off by backend MQTT provision/req. cfg client binds AppKey
+// and sets pub addr. SETTINGS=y restores everything across reboots
 
 #include "dp_mesh.h"
 
@@ -57,9 +49,8 @@ static const char *TAG = "dp_mesh";
 #define DP_MAX_SENSORS     8
 #define DP_PROV_START_ADDR (DP_GATEWAY_ADDR + 1)
 
-// Static keys remain — backend doesn't need rotated keys for the
-// prototype, and PB-ADV still establishes a unique per-device DevKey.
-// NetKey/AppKey are pushed onto each new node by the provisioner.
+// shared NetKey/AppKey ok for prototype. PB-ADV still gives each
+// node a unique DevKey. provisioner pushes these to new nodes
 static const uint8_t DP_NET_KEY[16] = {
     'd', 'o', 'c', 'k', 'p', 'u', 'l', 's', 'e', '-', 'n', 'e', 't', 'k', 'e', 'y',
 };
@@ -243,8 +234,7 @@ static void on_prov(esp_ble_mesh_prov_cb_event_t event, esp_ble_mesh_prov_cb_par
         ESP_LOGI(TAG, "node prov complete addr=0x%04x net_idx=0x%04x iv=0x%08" PRIx32,
                  param->node_prov_complete.addr, param->node_prov_complete.net_idx,
                  param->node_prov_complete.iv_index);
-        // wait for cfg server to receive AppKey Add + Model App Bind
-        // before firing ready — see on_cfg_server below
+        // wait for AppKey Add + Model App Bind via cfg server below
         break;
     case ESP_BLE_MESH_NODE_PROV_RESET_EVT:
         ESP_LOGW(TAG, "node prov reset");
@@ -367,13 +357,12 @@ static void on_cfg_server(esp_ble_mesh_cfg_server_cb_event_t event,
     uint32_t op = param->ctx.recv_op;
     ESP_LOGI(TAG, "cfg srv state-change op=0x%04" PRIx32, op);
     if (op == ESP_BLE_MESH_MODEL_OP_MODEL_APP_BIND || op == ESP_BLE_MESH_MODEL_OP_MODEL_PUB_SET) {
-        // bind or pub-set received — vendor model can publish now
+        // bind or pub-set received vendor model can publish
         fire_sensor_ready();
     }
 }
 
-// cfg client callback fires on the GATEWAY side after each
-// AppKeyAdd/ModelAppBind/ModelPubSet response
+// gateway-side cfg client cb. fires after each AppKeyAdd/Bind/PubSet response
 static void on_cfg_client(esp_ble_mesh_cfg_client_cb_event_t event,
                           esp_ble_mesh_cfg_client_cb_param_t *param)
 {
@@ -388,7 +377,7 @@ static void on_cfg_client(esp_ble_mesh_cfg_client_cb_event_t event,
         return;
     }
     if (event == ESP_BLE_MESH_CFG_CLIENT_PUBLISH_EVT) {
-        // ignore — publish notifications, not response to our cmd
+        // ignore not response to our cmd
         return;
     }
     cfg_step_advance(s_prov_target_addr);
@@ -564,8 +553,7 @@ esp_err_t dp_mesh_gateway_provision(const uint8_t uuid[16], const uint8_t *stati
 static void make_dev_uuid(void)
 {
     if (s_role == DP_MESH_ROLE_SENSOR) {
-        // factory QR-encoded UUID — match between sensor beacon and
-        // backend's claim JWT
+        // factory QR-encoded UUID. matches sensor beacon to backend claim JWT
         if (dp_prov_get_dev_uuid(s_dev_uuid) == ESP_OK) {
             return;
         }
@@ -588,8 +576,8 @@ esp_err_t dp_mesh_init(const dp_mesh_cfg_t *cfg)
     s_ready_cb = cfg->sensor_ready;
     make_dev_uuid();
 
-    // prov_unicast_addr / prov_start_address are const members — must
-    // initialize via designated init then memcpy
+    // prov_unicast_addr / prov_start_address are const fields. need
+    // designated init + memcpy to populate
     if (s_role == DP_MESH_ROLE_GATEWAY) {
         const esp_ble_mesh_prov_t init = {
             .uuid = s_dev_uuid,
@@ -674,7 +662,7 @@ esp_err_t dp_mesh_init(const dp_mesh_cfg_t *cfg)
         s_local_addr = DP_GATEWAY_ADDR;
     } else {
         if (esp_ble_mesh_node_is_provisioned()) {
-            // restored from NVS — bindings + pub already in cfg_srv state
+            // restored from NVS bindings + pub already set
             fire_sensor_ready();
         } else {
             err = esp_ble_mesh_node_prov_enable(ESP_BLE_MESH_PROV_ADV);
@@ -685,7 +673,7 @@ esp_err_t dp_mesh_init(const dp_mesh_cfg_t *cfg)
         }
     }
 
-    // log UUID hex so bench tests can copy-paste it into mosquitto_pub
+    // log UUID hex for sim-adopt copy-paste
     ESP_LOGI(TAG, "ready role=%s uuid=%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
              s_role == DP_MESH_ROLE_GATEWAY ? "gateway" : "sensor",
              s_dev_uuid[0], s_dev_uuid[1], s_dev_uuid[2], s_dev_uuid[3],

--- a/components/dp_mesh/dp_mesh.c
+++ b/components/dp_mesh/dp_mesh.c
@@ -50,11 +50,11 @@ static const char *TAG = "dp_mesh";
 #define DP_OP_DIAG_PUB   ESP_BLE_MESH_MODEL_OP_3(0x02, DP_CID)
 #define DP_PUB_BUF_LEN   (BERTH_DIAG_WIRE_LEN + 3)
 
-#define DP_NET_IDX      0x0000
-#define DP_APP_IDX      0x0000
-#define DP_GATEWAY_ADDR 0x0001
-#define DP_GROUP_ADDR   0xC000
-#define DP_MAX_SENSORS  8
+#define DP_NET_IDX         0x0000
+#define DP_APP_IDX         0x0000
+#define DP_GATEWAY_ADDR    0x0001
+#define DP_GROUP_ADDR      0xC000
+#define DP_MAX_SENSORS     8
 #define DP_PROV_START_ADDR (DP_GATEWAY_ADDR + 1)
 
 // Static keys remain — backend doesn't need rotated keys for the
@@ -258,8 +258,7 @@ static void on_prov(esp_ble_mesh_prov_cb_event_t event, esp_ble_mesh_prov_cb_par
         ESP_LOGI(TAG, "gw netkey added err=%d", param->provisioner_add_net_key_comp.err_code);
         break;
     case ESP_BLE_MESH_PROVISIONER_UPDATE_LOCAL_NET_KEY_COMP_EVT:
-        ESP_LOGI(TAG, "gw netkey updated err=%d",
-                 param->provisioner_update_net_key_comp.err_code);
+        ESP_LOGI(TAG, "gw netkey updated err=%d", param->provisioner_update_net_key_comp.err_code);
         break;
     case ESP_BLE_MESH_PROVISIONER_ADD_LOCAL_APP_KEY_COMP_EVT:
         ESP_LOGI(TAG, "gw appkey added err=%d", param->provisioner_add_app_key_comp.err_code);
@@ -276,8 +275,7 @@ static void on_prov(esp_ble_mesh_prov_cb_event_t event, esp_ble_mesh_prov_cb_par
         break;
     }
     case ESP_BLE_MESH_PROVISIONER_PROV_LINK_OPEN_EVT:
-        ESP_LOGI(TAG, "gw prov link open bearer=%d",
-                 param->provisioner_prov_link_open.bearer);
+        ESP_LOGI(TAG, "gw prov link open bearer=%d", param->provisioner_prov_link_open.bearer);
         break;
     case ESP_BLE_MESH_PROVISIONER_PROV_LINK_CLOSE_EVT:
         ESP_LOGW(TAG, "gw prov link close bearer=%d reason=%d",
@@ -339,8 +337,8 @@ static void on_model(esp_ble_mesh_model_cb_event_t event, esp_ble_mesh_model_cb_
             }
         } else if (param->model_operation.opcode == DP_OP_DIAG_PUB) {
             berth_diag_t d;
-            if (berth_diag_unpack(param->model_operation.msg, param->model_operation.length,
-                                  &d) != ESP_OK) {
+            if (berth_diag_unpack(param->model_operation.msg, param->model_operation.length, &d) !=
+                ESP_OK) {
                 ESP_LOGW(TAG, "rx diag unpack fail len=%u", param->model_operation.length);
                 break;
             }
@@ -368,8 +366,7 @@ static void on_cfg_server(esp_ble_mesh_cfg_server_cb_event_t event,
     }
     uint32_t op = param->ctx.recv_op;
     ESP_LOGI(TAG, "cfg srv state-change op=0x%04" PRIx32, op);
-    if (op == ESP_BLE_MESH_MODEL_OP_MODEL_APP_BIND ||
-        op == ESP_BLE_MESH_MODEL_OP_MODEL_PUB_SET) {
+    if (op == ESP_BLE_MESH_MODEL_OP_MODEL_APP_BIND || op == ESP_BLE_MESH_MODEL_OP_MODEL_PUB_SET) {
         // bind or pub-set received — vendor model can publish now
         fire_sensor_ready();
     }
@@ -638,8 +635,8 @@ esp_err_t dp_mesh_init(const dp_mesh_cfg_t *cfg)
         }
     }
 
-    err = esp_ble_mesh_init(&prov_cfg,
-                            s_role == DP_MESH_ROLE_GATEWAY ? &comp_gateway : &comp_sensor);
+    err =
+        esp_ble_mesh_init(&prov_cfg, s_role == DP_MESH_ROLE_GATEWAY ? &comp_gateway : &comp_sensor);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_ble_mesh_init err=%d", err);
         return err;
@@ -661,8 +658,8 @@ esp_err_t dp_mesh_init(const dp_mesh_cfg_t *cfg)
             ESP_LOGE(TAG, "add_local_app_key err=%d", err);
             return err;
         }
-        err = esp_ble_mesh_provisioner_bind_app_key_to_local_model(
-            DP_GATEWAY_ADDR, DP_APP_IDX, DP_VND_MODEL_ID, DP_CID);
+        err = esp_ble_mesh_provisioner_bind_app_key_to_local_model(DP_GATEWAY_ADDR, DP_APP_IDX,
+                                                                   DP_VND_MODEL_ID, DP_CID);
         if (err != ESP_OK) {
             ESP_LOGE(TAG, "local bind err=%d", err);
             return err;

--- a/components/dp_mesh/dp_mesh.c
+++ b/components/dp_mesh/dp_mesh.c
@@ -1,24 +1,17 @@
-// BLE Mesh wrapper using Espressif's esp_ble_mesh stack on the NimBLE
-// host. We deliberately avoid the in-tree NimBLE-mesh component (under
-// `bt/host/nimble/.../mesh/`) because its FreeRTOS port is incomplete:
-// per-buffer adv events are never `ble_npl_event_init`'d, the legacy
-// adv worker thread is gated `#ifdef MYNEWT`, and the IDF reference
-// `blemesh` example never exercises publish/subscribe — so the bug
-// surface is wide.
+// BLE Mesh wrapper using esp_ble_mesh on NimBLE host. (NimBLE-mesh is
+// broken: per-buffer adv events never get ble_npl_event_init'd, legacy
+// adv worker is gated #ifdef MYNEWT, IDF blemesh example doesn't
+// exercise pub/sub.)
 //
-// Topology: hub-and-spoke. Sensor nodes publish a packed
-// `berth_status_t` on a shared vendor model; the gateway subscribes to
-// the same group address and decodes each message into a
-// `dp_mesh_status_handler_t` callback.
+// Topology: hub-and-spoke. Sensor=NODE, gateway=PROVISIONER. Real
+// PB-ADV: sensor advertises unprov beacon on first boot, gateway
+// provisions on demand from MQTT request, then binds AppKey + sets
+// publication via cfg client. Subsequent boots restore from NVS via
+// CONFIG_BLE_MESH_SETTINGS=y.
 //
-// Self-provisioning: each node runs as its own one-device "provisioner"
-// (esp_ble_mesh provisioner role) and uses the local-data API to add a
-// shared NetKey/AppKey, bind the AppKey to the vendor model, and set
-// publication or subscription. There is no on-air provisioning
-// handshake — every node is hard-coded with the same keys and a
-// deterministic unicast address derived from CONFIG_DOCKPULSE_NODE_ID.
-// Fine for the prototype; not suitable for production (no auth, shared
-// static keys)
+// Earlier self-provisioning hack (both sides as provisioners with
+// shared keys + phantom-peer registration) is gone — see git for the
+// archaeology.
 
 #include "dp_mesh.h"
 
@@ -28,6 +21,7 @@
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_mac.h"
+#include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 
@@ -43,19 +37,10 @@
 #include "esp_ble_mesh_networking_api.h"
 #include "esp_ble_mesh_provisioning_api.h"
 
-void ble_store_config_init(void);
+#include "dp_prov.h"
+#include "sdkconfig.h"
 
-// Internal esp_ble_mesh API for stuffing a phantom node into the
-// provisioner's known-nodes DB. Needed because core/net.c:1885 silently
-// drops mesh packets whose `src` isn't in that DB when running as a
-// provisioner — see comment in dp_mesh_init() near register_phantom_peer.
-// `bt_mesh_addr_t` is pulled in transitively via esp_ble_mesh_defs.h →
-// proxy_server.h → mesh/adapter.h, so we only need the function decl
-extern int bt_mesh_provisioner_provision(const bt_mesh_addr_t *addr, const uint8_t uuid[16],
-                                         uint16_t oob_info, uint16_t unicast_addr,
-                                         uint8_t element_num, uint16_t net_idx, uint8_t flags,
-                                         uint32_t iv_index, const uint8_t dev_key[16],
-                                         uint16_t *index, bool nppi);
+void ble_store_config_init(void);
 
 static const char *TAG = "dp_mesh";
 
@@ -63,20 +48,18 @@ static const char *TAG = "dp_mesh";
 #define DP_VND_MODEL_ID  0x0001
 #define DP_OP_STATUS_PUB ESP_BLE_MESH_MODEL_OP_3(0x01, DP_CID)
 #define DP_OP_DIAG_PUB   ESP_BLE_MESH_MODEL_OP_3(0x02, DP_CID)
-// larger message (diag) + 3-byte vendor opcode
-#define DP_PUB_BUF_LEN (BERTH_DIAG_WIRE_LEN + 3)
+#define DP_PUB_BUF_LEN   (BERTH_DIAG_WIRE_LEN + 3)
 
 #define DP_NET_IDX      0x0000
 #define DP_APP_IDX      0x0000
 #define DP_GATEWAY_ADDR 0x0001
 #define DP_GROUP_ADDR   0xC000
-// Pre-registered sensor address range on the gateway. Must be <=
-// CONFIG_BLE_MESH_MAX_PROV_NODES (default 10)
-#define DP_MAX_SENSORS 8
+#define DP_MAX_SENSORS  8
+#define DP_PROV_START_ADDR (DP_GATEWAY_ADDR + 1)
 
-_Static_assert(CONFIG_DOCKPULSE_NODE_ID >= 1 && CONFIG_DOCKPULSE_NODE_ID <= DP_MAX_SENSORS,
-               "DOCKPULSE_NODE_ID out of DP_MAX_SENSORS range — gateway will drop frames");
-
+// Static keys remain — backend doesn't need rotated keys for the
+// prototype, and PB-ADV still establishes a unique per-device DevKey.
+// NetKey/AppKey are pushed onto each new node by the provisioner.
 static const uint8_t DP_NET_KEY[16] = {
     'd', 'o', 'c', 'k', 'p', 'u', 'l', 's', 'e', '-', 'n', 'e', 't', 'k', 'e', 'y',
 };
@@ -85,12 +68,37 @@ static const uint8_t DP_APP_KEY[16] = {
 };
 
 static dp_mesh_role_t s_role;
-static dp_mesh_status_handler_t s_handler;
-static dp_mesh_diag_handler_t s_diag_handler;
+static dp_mesh_status_handler_t s_status_cb;
+static dp_mesh_diag_handler_t s_diag_cb;
+static dp_mesh_sensor_ready_cb_t s_ready_cb;
 static SemaphoreHandle_t s_bt_sync;
 static uint16_t s_local_addr;
 static uint8_t s_dev_uuid[16];
 static uint8_t s_own_addr_type;
+static bool s_sensor_ready_fired;
+
+// gateway provisioning state
+static dp_mesh_prov_done_cb_t s_prov_cb;
+static void *s_prov_ctx;
+static uint8_t s_prov_uuid[16];
+static bool s_prov_in_flight;
+static uint16_t s_prov_target_addr;
+static uint8_t s_prov_dev_key[16];
+static esp_timer_handle_t s_prov_timer;
+
+// cfg client step machine for post-PB-ADV configuration
+typedef enum {
+    CFG_STEP_IDLE = 0,
+    CFG_STEP_APP_KEY_ADD,
+    CFG_STEP_MODEL_APP_BIND,
+    CFG_STEP_MODEL_PUB_SET,
+    CFG_STEP_DONE,
+} cfg_step_t;
+static cfg_step_t s_cfg_step;
+
+static void prov_finish_ok(uint16_t addr, const uint8_t dev_key[16]);
+static void prov_finish_err(const char *code, const char *msg);
+static void cfg_step_advance(uint16_t addr);
 
 static esp_ble_mesh_cfg_srv_t cfg_srv = {
     .net_transmit = ESP_BLE_MESH_TRANSMIT(2, 20),
@@ -102,8 +110,16 @@ static esp_ble_mesh_cfg_srv_t cfg_srv = {
     .default_ttl = 7,
 };
 
-static esp_ble_mesh_model_t root_models[] = {
+// gateway-only cfg client model
+static esp_ble_mesh_client_t cfg_cli;
+
+static esp_ble_mesh_model_t root_models_sensor[] = {
     ESP_BLE_MESH_MODEL_CFG_SRV(&cfg_srv),
+};
+
+static esp_ble_mesh_model_t root_models_gateway[] = {
+    ESP_BLE_MESH_MODEL_CFG_SRV(&cfg_srv),
+    ESP_BLE_MESH_MODEL_CFG_CLI(&cfg_cli),
 };
 
 static esp_ble_mesh_model_op_t vnd_op[] = {
@@ -112,25 +128,31 @@ static esp_ble_mesh_model_op_t vnd_op[] = {
     ESP_BLE_MESH_MODEL_OP_END,
 };
 
-ESP_BLE_MESH_MODEL_PUB_DEFINE(vnd_pub, DP_PUB_BUF_LEN, ROLE_PROVISIONER);
+ESP_BLE_MESH_MODEL_PUB_DEFINE(vnd_pub, DP_PUB_BUF_LEN, ROLE_NODE);
 
 static esp_ble_mesh_model_t vnd_models[] = {
     ESP_BLE_MESH_VENDOR_MODEL(DP_CID, DP_VND_MODEL_ID, vnd_op, &vnd_pub, NULL),
 };
 
-static esp_ble_mesh_elem_t elements[] = {
-    ESP_BLE_MESH_ELEMENT(0, root_models, vnd_models),
+// element built per role at init
+static esp_ble_mesh_elem_t elements_sensor[] = {
+    ESP_BLE_MESH_ELEMENT(0, root_models_sensor, vnd_models),
+};
+static esp_ble_mesh_elem_t elements_gateway[] = {
+    ESP_BLE_MESH_ELEMENT(0, root_models_gateway, vnd_models),
 };
 
-static esp_ble_mesh_comp_t comp = {
+static esp_ble_mesh_comp_t comp_sensor = {
     .cid = DP_CID,
-    .element_count = ARRAY_SIZE(elements),
-    .elements = elements,
+    .element_count = 1,
+    .elements = elements_sensor,
+};
+static esp_ble_mesh_comp_t comp_gateway = {
+    .cid = DP_CID,
+    .element_count = 1,
+    .elements = elements_gateway,
 };
 
-// Filled in at dp_mesh_init time — `prov_unicast_addr` is a const
-// member so we can't poke it after construction. We memcpy a fully
-// designated initializer into this storage on init
 static esp_ble_mesh_prov_t prov_cfg;
 
 static void on_ble_reset(int reason) { ESP_LOGW(TAG, "ble host reset reason=%d", reason); }
@@ -162,25 +184,41 @@ static esp_err_t bt_host_init(void)
     if (!s_bt_sync) {
         return ESP_ERR_NO_MEM;
     }
-
     esp_err_t ret = nimble_port_init();
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "nimble_port_init err=%d", ret);
         return ret;
     }
-
     ble_hs_cfg.reset_cb = on_ble_reset;
     ble_hs_cfg.sync_cb = on_ble_sync;
     ble_hs_cfg.store_status_cb = ble_store_util_status_rr;
     ble_store_config_init();
-
     nimble_port_freertos_init(host_task);
-
     if (xSemaphoreTake(s_bt_sync, pdMS_TO_TICKS(15000)) != pdTRUE) {
         ESP_LOGE(TAG, "ble host sync timeout");
         return ESP_ERR_TIMEOUT;
     }
     return ESP_OK;
+}
+
+// ----- prov + model event callbacks -----
+
+static void fire_sensor_ready(void)
+{
+    if (s_sensor_ready_fired) {
+        return;
+    }
+    uint16_t addr = esp_ble_mesh_get_primary_element_address();
+    s_local_addr = addr;
+    vnd_pub.publish_addr = DP_GROUP_ADDR;
+    vnd_pub.app_idx = DP_APP_IDX;
+    vnd_pub.ttl = 7;
+    vnd_pub.period = 0;
+    s_sensor_ready_fired = true;
+    ESP_LOGI(TAG, "sensor ready addr=0x%04x", addr);
+    if (s_ready_cb) {
+        s_ready_cb(addr);
+    }
 }
 
 static void on_prov(esp_ble_mesh_prov_cb_event_t event, esp_ble_mesh_prov_cb_param_t *param)
@@ -189,28 +227,90 @@ static void on_prov(esp_ble_mesh_prov_cb_event_t event, esp_ble_mesh_prov_cb_par
     case ESP_BLE_MESH_PROV_REGISTER_COMP_EVT:
         ESP_LOGI(TAG, "prov register err=%d", param->prov_register_comp.err_code);
         break;
+
+    // sensor (NODE)
+    case ESP_BLE_MESH_NODE_PROV_ENABLE_COMP_EVT:
+        ESP_LOGI(TAG, "node beacon on err=%d", param->node_prov_enable_comp.err_code);
+        break;
+    case ESP_BLE_MESH_NODE_PROV_LINK_OPEN_EVT:
+        ESP_LOGI(TAG, "node prov link open bearer=%d", param->node_prov_link_open.bearer);
+        break;
+    case ESP_BLE_MESH_NODE_PROV_LINK_CLOSE_EVT:
+        ESP_LOGI(TAG, "node prov link close bearer=%d reason=%d",
+                 param->node_prov_link_close.bearer, param->node_prov_link_close.reason);
+        break;
+    case ESP_BLE_MESH_NODE_PROV_COMPLETE_EVT:
+        ESP_LOGI(TAG, "node prov complete addr=0x%04x net_idx=0x%04x iv=0x%08" PRIx32,
+                 param->node_prov_complete.addr, param->node_prov_complete.net_idx,
+                 param->node_prov_complete.iv_index);
+        // wait for cfg server to receive AppKey Add + Model App Bind
+        // before firing ready — see on_cfg_server below
+        break;
+    case ESP_BLE_MESH_NODE_PROV_RESET_EVT:
+        ESP_LOGW(TAG, "node prov reset");
+        break;
+
+    // gateway (PROVISIONER)
     case ESP_BLE_MESH_PROVISIONER_PROV_ENABLE_COMP_EVT:
-        ESP_LOGI(TAG, "provisioner enabled err=%d", param->provisioner_prov_enable_comp.err_code);
+        ESP_LOGI(TAG, "gw prov enable err=%d", param->provisioner_prov_enable_comp.err_code);
         break;
     case ESP_BLE_MESH_PROVISIONER_ADD_LOCAL_NET_KEY_COMP_EVT:
-        ESP_LOGI(TAG, "local netkey added err=%d", param->provisioner_add_net_key_comp.err_code);
+        ESP_LOGI(TAG, "gw netkey added err=%d", param->provisioner_add_net_key_comp.err_code);
         break;
     case ESP_BLE_MESH_PROVISIONER_UPDATE_LOCAL_NET_KEY_COMP_EVT:
-        ESP_LOGI(TAG, "local netkey updated err=%d",
+        ESP_LOGI(TAG, "gw netkey updated err=%d",
                  param->provisioner_update_net_key_comp.err_code);
         break;
     case ESP_BLE_MESH_PROVISIONER_ADD_LOCAL_APP_KEY_COMP_EVT:
-        ESP_LOGI(TAG, "local appkey added err=%d", param->provisioner_add_app_key_comp.err_code);
+        ESP_LOGI(TAG, "gw appkey added err=%d", param->provisioner_add_app_key_comp.err_code);
         break;
     case ESP_BLE_MESH_PROVISIONER_BIND_APP_KEY_TO_MODEL_COMP_EVT:
-        ESP_LOGI(TAG, "appkey bound to vnd model err=%d",
+        ESP_LOGI(TAG, "gw local bind err=%d",
                  param->provisioner_bind_app_key_to_model_comp.err_code);
         break;
-    case ESP_BLE_MESH_MODEL_SUBSCRIBE_GROUP_ADDR_COMP_EVT:
-        ESP_LOGI(TAG, "model subscribed to group=0x%04x err=%d",
-                 param->model_sub_group_addr_comp.group_addr,
-                 param->model_sub_group_addr_comp.err_code);
+    case ESP_BLE_MESH_PROVISIONER_RECV_UNPROV_ADV_PKT_EVT: {
+        const uint8_t *u = param->provisioner_recv_unprov_adv_pkt.dev_uuid;
+        ESP_LOGD(TAG, "unprov beacon uuid=%02x%02x%02x...", u[0], u[1], u[2]);
+        // matching via set_dev_uuid_match auto-triggers provisioning,
+        // nothing to do here besides log
         break;
+    }
+    case ESP_BLE_MESH_PROVISIONER_PROV_LINK_OPEN_EVT:
+        ESP_LOGI(TAG, "gw prov link open bearer=%d",
+                 param->provisioner_prov_link_open.bearer);
+        break;
+    case ESP_BLE_MESH_PROVISIONER_PROV_LINK_CLOSE_EVT:
+        ESP_LOGW(TAG, "gw prov link close bearer=%d reason=%d",
+                 param->provisioner_prov_link_close.bearer,
+                 param->provisioner_prov_link_close.reason);
+        if (s_prov_in_flight && s_cfg_step < CFG_STEP_APP_KEY_ADD) {
+            prov_finish_err("link-close", NULL);
+        }
+        break;
+    case ESP_BLE_MESH_PROVISIONER_PROV_COMPLETE_EVT: {
+        uint16_t addr = param->provisioner_prov_complete.unicast_addr;
+        ESP_LOGI(TAG, "gw prov complete addr=0x%04x node_idx=%u", addr,
+                 param->provisioner_prov_complete.node_idx);
+        s_prov_target_addr = addr;
+        const esp_ble_mesh_node_t *node = esp_ble_mesh_provisioner_get_node_with_addr(addr);
+        if (node) {
+            memcpy(s_prov_dev_key, node->dev_key, 16);
+        } else {
+            ESP_LOGW(TAG, "node lookup failed for addr=0x%04x", addr);
+            memset(s_prov_dev_key, 0, 16);
+        }
+        cfg_step_advance(addr);
+        break;
+    }
+    case ESP_BLE_MESH_PROVISIONER_SET_DEV_UUID_MATCH_COMP_EVT:
+        ESP_LOGI(TAG, "gw uuid-match set err=%d",
+                 param->provisioner_set_dev_uuid_match_comp.err_code);
+        break;
+    case ESP_BLE_MESH_PROVISIONER_SET_STATIC_OOB_VALUE_COMP_EVT:
+        ESP_LOGI(TAG, "gw static-oob set err=%d",
+                 param->provisioner_set_static_oob_val_comp.err_code);
+        break;
+
     default:
         ESP_LOGD(TAG, "prov event %d", (int)event);
         break;
@@ -221,7 +321,7 @@ static void on_model(esp_ble_mesh_model_cb_event_t event, esp_ble_mesh_model_cb_
 {
     switch (event) {
     case ESP_BLE_MESH_MODEL_OPERATION_EVT: {
-        ESP_LOGI(TAG, "model rx opcode=0x%06" PRIx32 " src=0x%04x len=%u",
+        ESP_LOGD(TAG, "model rx opcode=0x%06" PRIx32 " src=0x%04x len=%u",
                  param->model_operation.opcode, param->model_operation.ctx->addr,
                  param->model_operation.length);
         if (s_role != DP_MESH_ROLE_GATEWAY) {
@@ -229,83 +329,255 @@ static void on_model(esp_ble_mesh_model_cb_event_t event, esp_ble_mesh_model_cb_
         }
         if (param->model_operation.opcode == DP_OP_STATUS_PUB) {
             berth_status_t s;
-            esp_err_t err =
-                berth_status_unpack(param->model_operation.msg, param->model_operation.length, &s);
-            if (err != ESP_OK) {
-                ESP_LOGW(TAG, "rx status unpack err=%d len=%u", err, param->model_operation.length);
+            if (berth_status_unpack(param->model_operation.msg, param->model_operation.length,
+                                    &s) != ESP_OK) {
+                ESP_LOGW(TAG, "rx status unpack fail len=%u", param->model_operation.length);
                 break;
             }
-            if (s_handler) {
-                s_handler(&s, param->model_operation.ctx->addr);
+            if (s_status_cb) {
+                s_status_cb(&s, param->model_operation.ctx->addr);
             }
         } else if (param->model_operation.opcode == DP_OP_DIAG_PUB) {
             berth_diag_t d;
-            esp_err_t err =
-                berth_diag_unpack(param->model_operation.msg, param->model_operation.length, &d);
-            if (err != ESP_OK) {
-                ESP_LOGW(TAG, "rx diag unpack err=%d len=%u", err, param->model_operation.length);
+            if (berth_diag_unpack(param->model_operation.msg, param->model_operation.length,
+                                  &d) != ESP_OK) {
+                ESP_LOGW(TAG, "rx diag unpack fail len=%u", param->model_operation.length);
                 break;
             }
-            if (s_diag_handler) {
-                s_diag_handler(&d, param->model_operation.ctx->addr);
+            if (s_diag_cb) {
+                s_diag_cb(&d, param->model_operation.ctx->addr);
             }
         }
         break;
     }
-    case ESP_BLE_MESH_MODEL_SEND_COMP_EVT:
-        ESP_LOGI(TAG, "model send comp opcode=0x%06" PRIx32 " err=%d",
-                 param->model_send_comp.opcode, param->model_send_comp.err_code);
-        break;
     case ESP_BLE_MESH_MODEL_PUBLISH_COMP_EVT:
-        ESP_LOGI(TAG, "publish comp err=%d", param->model_publish_comp.err_code);
-        break;
-    case ESP_BLE_MESH_CLIENT_MODEL_RECV_PUBLISH_MSG_EVT:
-        ESP_LOGI(TAG, "client rx publish opcode=0x%06" PRIx32 " src=0x%04x",
-                 param->client_recv_publish_msg.opcode, param->client_recv_publish_msg.ctx->addr);
+        ESP_LOGD(TAG, "publish comp err=%d", param->model_publish_comp.err_code);
         break;
     default:
-        ESP_LOGD(TAG, "model event %d", (int)event);
         break;
     }
 }
 
-static void register_phantom_peer(uint16_t addr)
+// cfg server callback fires on the SENSOR side when the provisioner
+// pushes AppKey Add / Model App Bind / Model Pub Set messages
+static void on_cfg_server(esp_ble_mesh_cfg_server_cb_event_t event,
+                          esp_ble_mesh_cfg_server_cb_param_t *param)
 {
-    if (addr == s_local_addr) {
+    if (event != ESP_BLE_MESH_CFG_SERVER_STATE_CHANGE_EVT) {
         return;
     }
-    // With CONFIG_BLE_MESH_SETTINGS=y the node DB is restored from NVS
-    // on boot, so peers from a previous session are already registered.
-    // Re-registering would fail with EEXIST — skip cleanly instead
-    if (esp_ble_mesh_provisioner_get_node_with_addr(addr)) {
-        ESP_LOGI(TAG, "phantom peer 0x%04x already in DB", addr);
-        return;
-    }
-    bt_mesh_addr_t bd_addr = {0};
-    uint8_t uuid[16] = {'d', 'p', '-', 'p', 'h', 'a', 'n', 't', 'o', 'm', 0};
-    uuid[14] = (uint8_t)(addr & 0xFF);
-    uuid[15] = (uint8_t)(addr >> 8);
-    uint8_t dev_key[16] = {0}; // unused, never send DEVKEY-encrypted msgs to peers
-    uint16_t index = 0;
-    int rc = bt_mesh_provisioner_provision(&bd_addr, uuid, 0, addr, 1, DP_NET_IDX, 0, 0, dev_key,
-                                           &index, false);
-    if (rc) {
-        ESP_LOGW(TAG, "phantom peer 0x%04x rc=%d", addr, rc);
-    } else {
-        ESP_LOGI(TAG, "phantom peer 0x%04x registered idx=%u", addr, index);
+    uint32_t op = param->ctx.recv_op;
+    ESP_LOGI(TAG, "cfg srv state-change op=0x%04" PRIx32, op);
+    if (op == ESP_BLE_MESH_MODEL_OP_MODEL_APP_BIND ||
+        op == ESP_BLE_MESH_MODEL_OP_MODEL_PUB_SET) {
+        // bind or pub-set received — vendor model can publish now
+        fire_sensor_ready();
     }
 }
+
+// cfg client callback fires on the GATEWAY side after each
+// AppKeyAdd/ModelAppBind/ModelPubSet response
+static void on_cfg_client(esp_ble_mesh_cfg_client_cb_event_t event,
+                          esp_ble_mesh_cfg_client_cb_param_t *param)
+{
+    if (!s_prov_in_flight) {
+        return;
+    }
+    int err = param->error_code;
+    uint32_t op = param->params ? param->params->opcode : 0;
+    ESP_LOGI(TAG, "cfg cli evt=%d op=0x%04" PRIx32 " err=%d", (int)event, op, err);
+    if (event == ESP_BLE_MESH_CFG_CLIENT_TIMEOUT_EVT || err != 0) {
+        prov_finish_err("cfg-fail", NULL);
+        return;
+    }
+    if (event == ESP_BLE_MESH_CFG_CLIENT_PUBLISH_EVT) {
+        // ignore — publish notifications, not response to our cmd
+        return;
+    }
+    cfg_step_advance(s_prov_target_addr);
+}
+
+// ----- gateway provisioning state machine -----
+
+static void prov_timer_cb(void *arg)
+{
+    (void)arg;
+    if (s_prov_in_flight) {
+        ESP_LOGW(TAG, "prov timeout uuid=%02x%02x...", s_prov_uuid[0], s_prov_uuid[1]);
+        prov_finish_err("timeout", NULL);
+    }
+}
+
+static void prov_finish_ok(uint16_t addr, const uint8_t dev_key[16])
+{
+    if (!s_prov_in_flight) {
+        return;
+    }
+    s_prov_in_flight = false;
+    s_cfg_step = CFG_STEP_IDLE;
+    if (s_prov_timer) {
+        esp_timer_stop(s_prov_timer);
+    }
+    dp_mesh_prov_result_t res = {.ok = true, .unicast_addr = addr};
+    memcpy(res.dev_key, dev_key, 16);
+    if (s_prov_cb) {
+        s_prov_cb(&res, s_prov_ctx);
+    }
+    s_prov_cb = NULL;
+}
+
+static void prov_finish_err(const char *code, const char *msg)
+{
+    if (!s_prov_in_flight) {
+        return;
+    }
+    s_prov_in_flight = false;
+    s_cfg_step = CFG_STEP_IDLE;
+    if (s_prov_timer) {
+        esp_timer_stop(s_prov_timer);
+    }
+    dp_mesh_prov_result_t res = {.ok = false, .err_code = code, .err_msg = msg};
+    if (s_prov_cb) {
+        s_prov_cb(&res, s_prov_ctx);
+    }
+    s_prov_cb = NULL;
+}
+
+static esp_err_t cfg_send(uint16_t addr, uint32_t opcode, esp_ble_mesh_cfg_client_set_state_t *set)
+{
+    // cfg cli is the second SIG model on our root element
+    esp_ble_mesh_client_common_param_t common = {
+        .opcode = opcode,
+        .model = &root_models_gateway[1],
+        .ctx =
+            {
+                .net_idx = DP_NET_IDX,
+                .app_idx = ESP_BLE_MESH_KEY_UNUSED,
+                .addr = addr,
+                .send_ttl = 7,
+            },
+        .msg_timeout = 5000,
+    };
+    return esp_ble_mesh_config_client_set_state(&common, set);
+}
+
+static void cfg_step_advance(uint16_t addr)
+{
+    s_cfg_step++;
+    esp_err_t err;
+    switch (s_cfg_step) {
+    case CFG_STEP_APP_KEY_ADD: {
+        esp_ble_mesh_cfg_client_set_state_t set = {0};
+        set.app_key_add.net_idx = DP_NET_IDX;
+        set.app_key_add.app_idx = DP_APP_IDX;
+        memcpy(set.app_key_add.app_key, DP_APP_KEY, 16);
+        err = cfg_send(addr, ESP_BLE_MESH_MODEL_OP_APP_KEY_ADD, &set);
+        if (err != ESP_OK) {
+            prov_finish_err("appkey-send", NULL);
+        }
+        break;
+    }
+    case CFG_STEP_MODEL_APP_BIND: {
+        esp_ble_mesh_cfg_client_set_state_t set = {0};
+        set.model_app_bind.element_addr = addr;
+        set.model_app_bind.model_app_idx = DP_APP_IDX;
+        set.model_app_bind.model_id = DP_VND_MODEL_ID;
+        set.model_app_bind.company_id = DP_CID;
+        err = cfg_send(addr, ESP_BLE_MESH_MODEL_OP_MODEL_APP_BIND, &set);
+        if (err != ESP_OK) {
+            prov_finish_err("bind-send", NULL);
+        }
+        break;
+    }
+    case CFG_STEP_MODEL_PUB_SET: {
+        esp_ble_mesh_cfg_client_set_state_t set = {0};
+        set.model_pub_set.element_addr = addr;
+        set.model_pub_set.publish_addr = DP_GROUP_ADDR;
+        set.model_pub_set.publish_app_idx = DP_APP_IDX;
+        set.model_pub_set.publish_ttl = 7;
+        set.model_pub_set.publish_period = 0;
+        set.model_pub_set.publish_retransmit = ESP_BLE_MESH_PUBLISH_TRANSMIT(1, 50);
+        set.model_pub_set.model_id = DP_VND_MODEL_ID;
+        set.model_pub_set.company_id = DP_CID;
+        err = cfg_send(addr, ESP_BLE_MESH_MODEL_OP_MODEL_PUB_SET, &set);
+        if (err != ESP_OK) {
+            prov_finish_err("pubset-send", NULL);
+        }
+        break;
+    }
+    case CFG_STEP_DONE:
+        prov_finish_ok(addr, s_prov_dev_key);
+        break;
+    default:
+        break;
+    }
+}
+
+esp_err_t dp_mesh_gateway_provision(const uint8_t uuid[16], const uint8_t *static_oob,
+                                    uint32_t timeout_ms, dp_mesh_prov_done_cb_t cb, void *ctx)
+{
+    if (s_role != DP_MESH_ROLE_GATEWAY) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (!uuid || !cb) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (s_prov_in_flight) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    s_prov_in_flight = true;
+    s_prov_cb = cb;
+    s_prov_ctx = ctx;
+    memcpy(s_prov_uuid, uuid, 16);
+    s_prov_target_addr = 0;
+    s_cfg_step = CFG_STEP_IDLE;
+
+    if (static_oob) {
+        esp_err_t err = esp_ble_mesh_provisioner_set_static_oob_value(static_oob, 16);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "set_static_oob err=%d", err);
+            s_prov_in_flight = false;
+            return err;
+        }
+    }
+
+    // match full 16-byte UUID, auto-provision on match
+    esp_err_t err = esp_ble_mesh_provisioner_set_dev_uuid_match(uuid, 16, 0, true);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "set_dev_uuid_match err=%d", err);
+        s_prov_in_flight = false;
+        return err;
+    }
+
+    if (!s_prov_timer) {
+        const esp_timer_create_args_t a = {.callback = prov_timer_cb, .name = "dp_prov_to"};
+        esp_timer_create(&a, &s_prov_timer);
+    }
+    if (s_prov_timer) {
+        esp_timer_stop(s_prov_timer);
+        esp_timer_start_once(s_prov_timer, (uint64_t)timeout_ms * 1000);
+    }
+    ESP_LOGI(TAG, "prov start uuid=%02x%02x%02x... timeout=%" PRIu32 "ms", uuid[0], uuid[1],
+             uuid[2], timeout_ms);
+    return ESP_OK;
+}
+
+// ----- init -----
 
 static void make_dev_uuid(void)
 {
+    if (s_role == DP_MESH_ROLE_SENSOR) {
+        // factory QR-encoded UUID — match between sensor beacon and
+        // backend's claim JWT
+        if (dp_prov_get_dev_uuid(s_dev_uuid) == ESP_OK) {
+            return;
+        }
+    }
     uint8_t mac[6] = {0};
     esp_efuse_mac_get_default(mac);
     memset(s_dev_uuid, 0, sizeof(s_dev_uuid));
     memcpy(s_dev_uuid, mac, sizeof(mac));
     s_dev_uuid[6] = (uint8_t)s_role;
-    uint8_t node_id = 0;
-    dp_common_get_node_id(&node_id);
-    s_dev_uuid[7] = node_id;
 }
 
 esp_err_t dp_mesh_init(const dp_mesh_cfg_t *cfg)
@@ -314,183 +586,154 @@ esp_err_t dp_mesh_init(const dp_mesh_cfg_t *cfg)
         return ESP_ERR_INVALID_ARG;
     }
     s_role = cfg->role;
-    s_handler = cfg->status_cb;
-    s_diag_handler = cfg->diag_cb;
+    s_status_cb = cfg->status_cb;
+    s_diag_cb = cfg->diag_cb;
+    s_ready_cb = cfg->sensor_ready;
     make_dev_uuid();
-    const dp_mesh_role_t role = cfg->role;
 
-    uint8_t node_id = 0;
-    dp_common_get_node_id(&node_id);
-    s_local_addr =
-        (role == DP_MESH_ROLE_GATEWAY) ? DP_GATEWAY_ADDR : (uint16_t)(DP_GATEWAY_ADDR + node_id);
-
-    const esp_ble_mesh_prov_t prov_init = {
-        .uuid = s_dev_uuid,
-        .prov_uuid = s_dev_uuid,
-        .prov_unicast_addr = s_local_addr,
-        // prov_start_address must be a valid unicast > prov_unicast_addr
-        // (the stack rejects 0xFFFF / group / RFU). We never actually
-        // onboard others — provisioner_prov_enable is called only so
-        // the local-data API will accept our key/bind calls — but the
-        // value still has to pass validation. 0x7FFF is the top of the
-        // unicast range, safely past anything we hand out ourselves
-        .prov_start_address = 0x7FFF,
-        .prov_attention = 0,
-        .prov_algorithm = 0,
-        .prov_pub_key_oob = 0,
-        .prov_static_oob_val = NULL,
-        .prov_static_oob_len = 0,
-        .flags = 0,
-        .iv_index = 0,
-    };
-    memcpy(&prov_cfg, &prov_init, sizeof(prov_cfg));
+    // prov_unicast_addr / prov_start_address are const members — must
+    // initialize via designated init then memcpy
+    if (s_role == DP_MESH_ROLE_GATEWAY) {
+        const esp_ble_mesh_prov_t init = {
+            .uuid = s_dev_uuid,
+            .prov_uuid = s_dev_uuid,
+            .prov_unicast_addr = DP_GATEWAY_ADDR,
+            .prov_start_address = DP_PROV_START_ADDR,
+        };
+        memcpy(&prov_cfg, &init, sizeof(prov_cfg));
+    } else {
+        // gateway pushes matching OOB from backend QR JWT before each
+        // flow via set_static_oob_value
+        static const uint8_t SENSOR_STATIC_OOB[16] = {
+            'd', 'p', '-', 's', 't', 'a', 't', 'i', 'c', '-', 'o', 'o', 'b', 0, 0, 0,
+        };
+        const esp_ble_mesh_prov_t init = {
+            .uuid = s_dev_uuid,
+            .static_val = SENSOR_STATIC_OOB,
+            .static_val_len = 16,
+        };
+        memcpy(&prov_cfg, &init, sizeof(prov_cfg));
+    }
 
     esp_err_t err = bt_host_init();
     if (err != ESP_OK) {
         return err;
     }
-
     err = esp_ble_mesh_register_prov_callback(on_prov);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "register prov cb err=%d", err);
         return err;
     }
-
     err = esp_ble_mesh_register_custom_model_callback(on_model);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "register model cb err=%d", err);
         return err;
     }
+    err = esp_ble_mesh_register_config_server_callback(on_cfg_server);
+    if (err != ESP_OK) {
+        return err;
+    }
+    if (s_role == DP_MESH_ROLE_GATEWAY) {
+        err = esp_ble_mesh_register_config_client_callback(on_cfg_client);
+        if (err != ESP_OK) {
+            return err;
+        }
+    }
 
-    err = esp_ble_mesh_init(&prov_cfg, &comp);
+    err = esp_ble_mesh_init(&prov_cfg,
+                            s_role == DP_MESH_ROLE_GATEWAY ? &comp_gateway : &comp_sensor);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_ble_mesh_init err=%d", err);
         return err;
     }
 
-    err = esp_ble_mesh_provisioner_prov_enable(ESP_BLE_MESH_PROV_ADV);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "provisioner_prov_enable err=%d", err);
-        return err;
-    }
-
-    // provisioner_prov_enable auto-creates a random primary subnet
-    // (net_idx=0). add_local_net_key explicitly rejects net_idx=0 — see
-    // esp_ble_mesh_networking_api.c — so to install our deterministic
-    // shared key we have to *update* the primary instead of adding a
-    // new one
-    err = esp_ble_mesh_provisioner_update_local_net_key(DP_NET_KEY, DP_NET_IDX);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "update_local_net_key err=%d", err);
-        return err;
-    }
-
-    err = esp_ble_mesh_provisioner_add_local_app_key(DP_APP_KEY, DP_NET_IDX, DP_APP_IDX);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "add_local_app_key err=%d", err);
-        return err;
-    }
-
-    // Provisioner-side bind: signature is (elem_addr, app_idx, model_id,
-    // company_id). The 0xFFFF cid sentinel is the *node*-side bind, a
-    // different API in local_data_operation_api.h
-    err = esp_ble_mesh_provisioner_bind_app_key_to_local_model(s_local_addr, DP_APP_IDX,
-                                                               DP_VND_MODEL_ID, DP_CID);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "bind_app_key err=%d", err);
-        return err;
-    }
-
-    if (role == DP_MESH_ROLE_SENSOR) {
-        vnd_pub.publish_addr = DP_GROUP_ADDR;
-        vnd_pub.app_idx = DP_APP_IDX;
-        vnd_pub.ttl = 7;
-        vnd_pub.period = 0;
-
-        // The gateway runs as a provisioner; its receive path drops
-        // packets whose source unicast isn't in its node DB. The
-        // sensor must therefore be registered as a known node on the
-        // gateway. We do the inverse here so each side accepts the
-        // other's traffic (the gateway itself runs the matching loop
-        // below). See bt_mesh_provisioner_get_node_with_addr filter
-        // in core/net.c:1885
-        register_phantom_peer(DP_GATEWAY_ADDR);
-    } else {
-        err = esp_ble_mesh_model_subscribe_group_addr(s_local_addr, DP_CID, DP_VND_MODEL_ID,
-                                                      DP_GROUP_ADDR);
+    if (s_role == DP_MESH_ROLE_GATEWAY) {
+        err = esp_ble_mesh_provisioner_prov_enable(ESP_BLE_MESH_PROV_ADV);
         if (err != ESP_OK) {
-            ESP_LOGE(TAG, "subscribe_group err=%d", err);
             return err;
         }
-
-        // Pre-register every possible sensor address. Inflates the
-        // node DB by DP_MAX_SENSORS entries even if some slots are
-        // never used; cheap
-        for (uint16_t i = 0; i < DP_MAX_SENSORS; i++) {
-            register_phantom_peer(DP_GATEWAY_ADDR + 1 + i);
+        // primary subnet auto-created with random key; force ours
+        err = esp_ble_mesh_provisioner_update_local_net_key(DP_NET_KEY, DP_NET_IDX);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "update_local_net_key err=%d", err);
+            return err;
+        }
+        err = esp_ble_mesh_provisioner_add_local_app_key(DP_APP_KEY, DP_NET_IDX, DP_APP_IDX);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "add_local_app_key err=%d", err);
+            return err;
+        }
+        err = esp_ble_mesh_provisioner_bind_app_key_to_local_model(
+            DP_GATEWAY_ADDR, DP_APP_IDX, DP_VND_MODEL_ID, DP_CID);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "local bind err=%d", err);
+            return err;
+        }
+        // gateway subscribes the group so it receives sensor publications
+        err = esp_ble_mesh_model_subscribe_group_addr(DP_GATEWAY_ADDR, DP_CID, DP_VND_MODEL_ID,
+                                                      DP_GROUP_ADDR);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "group sub err=%d", err);
+            return err;
+        }
+        s_local_addr = DP_GATEWAY_ADDR;
+    } else {
+        if (esp_ble_mesh_node_is_provisioned()) {
+            // restored from NVS — bindings + pub already in cfg_srv state
+            fire_sensor_ready();
+        } else {
+            err = esp_ble_mesh_node_prov_enable(ESP_BLE_MESH_PROV_ADV);
+            if (err != ESP_OK) {
+                ESP_LOGE(TAG, "node_prov_enable err=%d", err);
+                return err;
+            }
         }
     }
 
-    ESP_LOGI(TAG, "ready role=%s addr=0x%04x", role == DP_MESH_ROLE_GATEWAY ? "gateway" : "sensor",
-             s_local_addr);
+    ESP_LOGI(TAG, "ready role=%s", s_role == DP_MESH_ROLE_GATEWAY ? "gateway" : "sensor");
     return ESP_OK;
 }
 
 esp_err_t dp_mesh_publish_status(const berth_status_t *s)
 {
-    if (!s) {
+    if (!s || s_role != DP_MESH_ROLE_SENSOR) {
         return ESP_ERR_INVALID_ARG;
     }
-    if (s_role != DP_MESH_ROLE_SENSOR) {
+    if (!s_sensor_ready_fired || vnd_pub.publish_addr == ESP_BLE_MESH_ADDR_UNASSIGNED) {
         return ESP_ERR_INVALID_STATE;
     }
-    if (vnd_pub.publish_addr == ESP_BLE_MESH_ADDR_UNASSIGNED) {
-        return ESP_ERR_INVALID_STATE;
-    }
-
     uint8_t wire[BERTH_STATUS_WIRE_LEN];
     size_t wire_len = 0;
     esp_err_t err = berth_status_pack(s, wire, sizeof(wire), &wire_len);
     if (err != ESP_OK) {
         return err;
     }
-
     err = esp_ble_mesh_model_publish(&vnd_models[0], DP_OP_STATUS_PUB, (uint16_t)wire_len, wire,
-                                     ROLE_PROVISIONER);
+                                     ROLE_NODE);
     if (err != ESP_OK) {
         ESP_LOGW(TAG, "publish err=%d", err);
         return ESP_FAIL;
     }
-    ESP_LOGD(TAG, "published berth_id=%u occupied=%d raw_mm=%u", s->berth_id, s->occupied,
-             s->sensor_raw_mm);
     return ESP_OK;
 }
 
 esp_err_t dp_mesh_publish_diag(const berth_diag_t *d)
 {
-    if (!d) {
+    if (!d || s_role != DP_MESH_ROLE_SENSOR) {
         return ESP_ERR_INVALID_ARG;
     }
-    if (s_role != DP_MESH_ROLE_SENSOR) {
+    if (!s_sensor_ready_fired || vnd_pub.publish_addr == ESP_BLE_MESH_ADDR_UNASSIGNED) {
         return ESP_ERR_INVALID_STATE;
     }
-    if (vnd_pub.publish_addr == ESP_BLE_MESH_ADDR_UNASSIGNED) {
-        return ESP_ERR_INVALID_STATE;
-    }
-
     uint8_t wire[BERTH_DIAG_WIRE_LEN];
     size_t wire_len = 0;
     esp_err_t err = berth_diag_pack(d, wire, sizeof(wire), &wire_len);
     if (err != ESP_OK) {
         return err;
     }
-
     err = esp_ble_mesh_model_publish(&vnd_models[0], DP_OP_DIAG_PUB, (uint16_t)wire_len, wire,
-                                     ROLE_PROVISIONER);
+                                     ROLE_NODE);
     if (err != ESP_OK) {
         ESP_LOGW(TAG, "publish diag err=%d", err);
         return ESP_FAIL;
     }
-    ESP_LOGD(TAG, "published diag berth_id=%u raw_cm=%u", d->berth_id, d->raw_distance_cm);
     return ESP_OK;
 }

--- a/components/dp_mesh/dp_mesh.c
+++ b/components/dp_mesh/dp_mesh.c
@@ -685,7 +685,13 @@ esp_err_t dp_mesh_init(const dp_mesh_cfg_t *cfg)
         }
     }
 
-    ESP_LOGI(TAG, "ready role=%s", s_role == DP_MESH_ROLE_GATEWAY ? "gateway" : "sensor");
+    // log UUID hex so bench tests can copy-paste it into mosquitto_pub
+    ESP_LOGI(TAG, "ready role=%s uuid=%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+             s_role == DP_MESH_ROLE_GATEWAY ? "gateway" : "sensor",
+             s_dev_uuid[0], s_dev_uuid[1], s_dev_uuid[2], s_dev_uuid[3],
+             s_dev_uuid[4], s_dev_uuid[5], s_dev_uuid[6], s_dev_uuid[7],
+             s_dev_uuid[8], s_dev_uuid[9], s_dev_uuid[10], s_dev_uuid[11],
+             s_dev_uuid[12], s_dev_uuid[13], s_dev_uuid[14], s_dev_uuid[15]);
     return ESP_OK;
 }
 

--- a/components/dp_mesh/include/dp_mesh.h
+++ b/components/dp_mesh/include/dp_mesh.h
@@ -12,25 +12,48 @@ typedef enum {
     DP_MESH_ROLE_GATEWAY,
 } dp_mesh_role_t;
 
-// Status callback fired on the gateway when a sensor's berth_status_t
-// is received. `src_addr` is the mesh unicast address of the sender —
-// useful for diagnostics; the logical berth id lives in `s->berth_id`
 typedef void (*dp_mesh_status_handler_t)(const berth_status_t *s, uint16_t src_addr);
-
-// gateway rx callback for berth_diag_t
 typedef void (*dp_mesh_diag_handler_t)(const berth_diag_t *d, uint16_t src_addr);
 
-// Handlers are passed in at init time so they're stored before any
-// rx path can fire. Sensor role ignores both fields.
+// Sensor: fired when PB-ADV completes (first boot) or when stack
+// finishes restoring from NVS (subsequent boots). After this fires the
+// sensor may publish.
+typedef void (*dp_mesh_sensor_ready_cb_t)(uint16_t unicast_addr);
+
 typedef struct {
     dp_mesh_role_t role;
-    dp_mesh_status_handler_t status_cb;
-    dp_mesh_diag_handler_t diag_cb;
+    dp_mesh_status_handler_t status_cb;     // gateway only
+    dp_mesh_diag_handler_t diag_cb;         // gateway only
+    dp_mesh_sensor_ready_cb_t sensor_ready; // sensor only
 } dp_mesh_cfg_t;
 
 esp_err_t dp_mesh_init(const dp_mesh_cfg_t *cfg);
 esp_err_t dp_mesh_publish_status(const berth_status_t *s);
 esp_err_t dp_mesh_publish_diag(const berth_diag_t *d);
+
+// --- Gateway-only adoption API ---
+//
+// Result of a provision attempt. unicast_addr/dev_key only set on ok.
+typedef struct {
+    bool ok;
+    uint16_t unicast_addr;
+    uint8_t dev_key[16];
+    const char *err_code; // e.g. "timeout", "scan-miss", "bind-fail"
+    const char *err_msg;
+} dp_mesh_prov_result_t;
+
+typedef void (*dp_mesh_prov_done_cb_t)(const dp_mesh_prov_result_t *res, void *ctx);
+
+// Start provisioning a sensor identified by mesh UUID. The gateway scans
+// for a matching unprov beacon, runs PB-ADV, then binds AppKey + sets
+// publication on the new node's vendor model. cb fires once with the
+// outcome. Only one provision flow at a time — returns ESP_ERR_INVALID_STATE
+// if another is in flight.
+//
+// `static_oob` is the 16-byte value the backend extracted from the QR
+// claim JWT. Pass NULL for OOB-less provisioning (prototype testing).
+esp_err_t dp_mesh_gateway_provision(const uint8_t uuid[16], const uint8_t *static_oob,
+                                    uint32_t timeout_ms, dp_mesh_prov_done_cb_t cb, void *ctx);
 
 #ifdef __cplusplus
 }

--- a/components/dp_mesh/include/dp_mesh.h
+++ b/components/dp_mesh/include/dp_mesh.h
@@ -15,9 +15,7 @@ typedef enum {
 typedef void (*dp_mesh_status_handler_t)(const berth_status_t *s, uint16_t src_addr);
 typedef void (*dp_mesh_diag_handler_t)(const berth_diag_t *d, uint16_t src_addr);
 
-// Sensor: fired when PB-ADV completes (first boot) or when stack
-// finishes restoring from NVS (subsequent boots). After this fires the
-// sensor may publish.
+// sensor cb. fires after PB-ADV completes or NVS restore. publish ok after
 typedef void (*dp_mesh_sensor_ready_cb_t)(uint16_t unicast_addr);
 
 typedef struct {
@@ -31,9 +29,8 @@ esp_err_t dp_mesh_init(const dp_mesh_cfg_t *cfg);
 esp_err_t dp_mesh_publish_status(const berth_status_t *s);
 esp_err_t dp_mesh_publish_diag(const berth_diag_t *d);
 
-// --- Gateway-only adoption API ---
-//
-// Result of a provision attempt. unicast_addr/dev_key only set on ok.
+// --- gateway adoption API ---
+// unicast_addr/dev_key only set on ok
 typedef struct {
     bool ok;
     uint16_t unicast_addr;
@@ -44,14 +41,9 @@ typedef struct {
 
 typedef void (*dp_mesh_prov_done_cb_t)(const dp_mesh_prov_result_t *res, void *ctx);
 
-// Start provisioning a sensor identified by mesh UUID. The gateway scans
-// for a matching unprov beacon, runs PB-ADV, then binds AppKey + sets
-// publication on the new node's vendor model. cb fires once with the
-// outcome. Only one provision flow at a time — returns ESP_ERR_INVALID_STATE
-// if another is in flight.
-//
-// `static_oob` is the 16-byte value the backend extracted from the QR
-// claim JWT. Pass NULL for OOB-less provisioning (prototype testing).
+// scan for unprov beacon matching uuid. run PB-ADV. push AppKey + pub via
+// cfg client. cb fires once. one flow at a time else ESP_ERR_INVALID_STATE.
+// static_oob is 16 bytes from backend QR JWT. NULL for OOB-less prototype
 esp_err_t dp_mesh_gateway_provision(const uint8_t uuid[16], const uint8_t *static_oob,
                                     uint32_t timeout_ms, dp_mesh_prov_done_cb_t cb, void *ctx);
 

--- a/components/dp_prov/CMakeLists.txt
+++ b/components/dp_prov/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "dp_prov.c"
+    INCLUDE_DIRS "include"
+    REQUIRES nvs_flash esp_hw_support
+)

--- a/components/dp_prov/dp_prov.c
+++ b/components/dp_prov/dp_prov.c
@@ -1,0 +1,205 @@
+#include "dp_prov.h"
+
+#include <string.h>
+
+#include "esp_log.h"
+#include "esp_mac.h"
+#include "esp_system.h"
+#include "nvs.h"
+#include "nvs_flash.h"
+
+static const char *TAG = "dp_prov";
+
+#define NVS_NAMESPACE "dp_prov"
+#define NVS_TABLE_KEY "berths"
+
+#define DP_PROV_MAX_RECORDS 16
+
+typedef struct {
+    uint16_t unicast_addr; // 0 = empty
+    char berth_id[DP_PROV_BERTH_ID_MAX];
+} dp_prov_record_t;
+
+typedef struct {
+    uint8_t version;
+    uint8_t count;
+    uint16_t _pad;
+    dp_prov_record_t records[DP_PROV_MAX_RECORDS];
+} dp_prov_table_t;
+
+#define DP_PROV_TABLE_VERSION 1
+
+static dp_prov_table_t s_table;
+static bool s_loaded;
+
+static esp_err_t load_table(void)
+{
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READONLY, &h);
+    if (err == ESP_ERR_NVS_NOT_FOUND) {
+        memset(&s_table, 0, sizeof(s_table));
+        s_table.version = DP_PROV_TABLE_VERSION;
+        s_loaded = true;
+        return ESP_OK;
+    }
+    if (err != ESP_OK) {
+        return err;
+    }
+    size_t sz = sizeof(s_table);
+    err = nvs_get_blob(h, NVS_TABLE_KEY, &s_table, &sz);
+    nvs_close(h);
+    if (err == ESP_ERR_NVS_NOT_FOUND || sz != sizeof(s_table) ||
+        s_table.version != DP_PROV_TABLE_VERSION) {
+        memset(&s_table, 0, sizeof(s_table));
+        s_table.version = DP_PROV_TABLE_VERSION;
+    } else if (err != ESP_OK) {
+        return err;
+    }
+    s_loaded = true;
+    return ESP_OK;
+}
+
+static esp_err_t save_table(void)
+{
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &h);
+    if (err != ESP_OK) {
+        return err;
+    }
+    err = nvs_set_blob(h, NVS_TABLE_KEY, &s_table, sizeof(s_table));
+    if (err == ESP_OK) {
+        err = nvs_commit(h);
+    }
+    nvs_close(h);
+    return err;
+}
+
+esp_err_t dp_prov_init(void)
+{
+    if (s_loaded) {
+        return ESP_OK;
+    }
+    return load_table();
+}
+
+const char *dp_prov_lookup_berth(uint16_t unicast_addr)
+{
+    if (!s_loaded || unicast_addr == 0) {
+        return NULL;
+    }
+    for (size_t i = 0; i < DP_PROV_MAX_RECORDS; i++) {
+        if (s_table.records[i].unicast_addr == unicast_addr) {
+            return s_table.records[i].berth_id;
+        }
+    }
+    return NULL;
+}
+
+esp_err_t dp_prov_record_berth(uint16_t unicast_addr, const char *berth_id)
+{
+    if (!unicast_addr || !berth_id || !*berth_id) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (strnlen(berth_id, DP_PROV_BERTH_ID_MAX) >= DP_PROV_BERTH_ID_MAX) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+    if (!s_loaded) {
+        esp_err_t err = load_table();
+        if (err != ESP_OK) {
+            return err;
+        }
+    }
+    // hot-swap: drop any stale record bound to the same berth_id under
+    // a different unicast addr first
+    for (int i = 0; i < DP_PROV_MAX_RECORDS; i++) {
+        if (s_table.records[i].unicast_addr != 0 &&
+            s_table.records[i].unicast_addr != unicast_addr &&
+            strncmp(s_table.records[i].berth_id, berth_id, DP_PROV_BERTH_ID_MAX) == 0) {
+            ESP_LOGI(TAG, "hot-swap evict old unicast=0x%04x berth=%s",
+                     s_table.records[i].unicast_addr, s_table.records[i].berth_id);
+            memset(&s_table.records[i], 0, sizeof(s_table.records[i]));
+            if (s_table.count) {
+                s_table.count--;
+            }
+        }
+    }
+    int slot = -1, empty = -1;
+    for (int i = 0; i < DP_PROV_MAX_RECORDS; i++) {
+        if (s_table.records[i].unicast_addr == unicast_addr) {
+            slot = i;
+            break;
+        }
+        if (empty < 0 && s_table.records[i].unicast_addr == 0) {
+            empty = i;
+        }
+    }
+    if (slot < 0) {
+        if (empty < 0) {
+            ESP_LOGE(TAG, "no slot for unicast=0x%04x", unicast_addr);
+            return ESP_ERR_NO_MEM;
+        }
+        slot = empty;
+        s_table.count++;
+    }
+    s_table.records[slot].unicast_addr = unicast_addr;
+    strncpy(s_table.records[slot].berth_id, berth_id, DP_PROV_BERTH_ID_MAX - 1);
+    s_table.records[slot].berth_id[DP_PROV_BERTH_ID_MAX - 1] = '\0';
+    esp_err_t err = save_table();
+    if (err == ESP_OK) {
+        ESP_LOGI(TAG, "record unicast=0x%04x berth=%s", unicast_addr,
+                 s_table.records[slot].berth_id);
+    }
+    return err;
+}
+
+esp_err_t dp_prov_forget_unicast(uint16_t unicast_addr)
+{
+    if (!s_loaded) {
+        esp_err_t err = load_table();
+        if (err != ESP_OK) {
+            return err;
+        }
+    }
+    for (int i = 0; i < DP_PROV_MAX_RECORDS; i++) {
+        if (s_table.records[i].unicast_addr == unicast_addr) {
+            memset(&s_table.records[i], 0, sizeof(s_table.records[i]));
+            if (s_table.count) {
+                s_table.count--;
+            }
+            return save_table();
+        }
+    }
+    return ESP_OK;
+}
+
+void dp_prov_factory_reset(void)
+{
+    ESP_LOGW(TAG, "factory reset: wiping NVS");
+    nvs_handle_t h;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &h) == ESP_OK) {
+        nvs_erase_all(h);
+        nvs_commit(h);
+        nvs_close(h);
+    }
+    // wipes BLE Mesh stack NVS too (lives in same partition under bt_mesh* namespaces)
+    nvs_flash_erase();
+    esp_restart();
+}
+
+esp_err_t dp_prov_get_dev_uuid(uint8_t out[DP_PROV_UUID_LEN])
+{
+    if (!out) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    uint8_t mac[6] = {0};
+    esp_err_t err = esp_efuse_mac_get_default(mac);
+    if (err != ESP_OK) {
+        return err;
+    }
+    // 6 bytes MAC + 10-byte marker so unprov beacons are easy to filter
+    memset(out, 0, DP_PROV_UUID_LEN);
+    memcpy(out, mac, sizeof(mac));
+    static const uint8_t MARKER[10] = {'D', 'O', 'C', 'K', 'P', 'U', 'L', 'S', 'E', 0x01};
+    memcpy(out + 6, MARKER, sizeof(MARKER));
+    return ESP_OK;
+}

--- a/components/dp_prov/include/dp_prov.h
+++ b/components/dp_prov/include/dp_prov.h
@@ -14,25 +14,23 @@ extern "C" {
 // "ksss-saltsjobaden-pier-1-t1" ~30 chars; 47 + null leaves headroom
 #define DP_PROV_BERTH_ID_MAX 48
 
-// Adoption metadata. Sensor uses none — provisioning state lives in
-// the esp_ble_mesh stack NVS (BLE_MESH_SETTINGS=y). Gateway stores
-// (unicast_addr -> berth_id) records, set from backend's provision/req
-// payload, used by uplink to render MQTT topic.
+// adoption metadata. sensor side none (mesh stack handles via SETTINGS=y).
+// gateway stores unicast_addr -> berth_id from backend provision/req
 
 esp_err_t dp_prov_init(void);
 
-// NULL if unknown. Pointer invalid after next record/forget call.
+// NULL if unknown. ptr invalid after next record/forget
 const char *dp_prov_lookup_berth(uint16_t unicast_addr);
 
-// Insert or overwrite. Hot-swap reuses the same berth_id with a new addr.
+// insert or overwrite. hot-swap reuses berth_id with new addr
 esp_err_t dp_prov_record_berth(uint16_t unicast_addr, const char *berth_id);
 
 esp_err_t dp_prov_forget_unicast(uint16_t unicast_addr);
 
-// Wipe dp_prov + ble mesh NVS, reboot. Does not return on success.
+// wipe dp_prov + mesh NVS reboot. does not return on success
 void dp_prov_factory_reset(void);
 
-// MAC-derived stable UUID. Factory QR encodes the same value.
+// MAC-derived stable UUID. factory QR encodes the same value
 esp_err_t dp_prov_get_dev_uuid(uint8_t out[DP_PROV_UUID_LEN]);
 
 #ifdef __cplusplus

--- a/components/dp_prov/include/dp_prov.h
+++ b/components/dp_prov/include/dp_prov.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define DP_PROV_UUID_LEN 16
+// "ksss-saltsjobaden-pier-1-t1" ~30 chars; 47 + null leaves headroom
+#define DP_PROV_BERTH_ID_MAX 48
+
+// Adoption metadata. Sensor uses none — provisioning state lives in
+// the esp_ble_mesh stack NVS (BLE_MESH_SETTINGS=y). Gateway stores
+// (unicast_addr -> berth_id) records, set from backend's provision/req
+// payload, used by uplink to render MQTT topic.
+
+esp_err_t dp_prov_init(void);
+
+// NULL if unknown. Pointer invalid after next record/forget call.
+const char *dp_prov_lookup_berth(uint16_t unicast_addr);
+
+// Insert or overwrite. Hot-swap reuses the same berth_id with a new addr.
+esp_err_t dp_prov_record_berth(uint16_t unicast_addr, const char *berth_id);
+
+esp_err_t dp_prov_forget_unicast(uint16_t unicast_addr);
+
+// Wipe dp_prov + ble mesh NVS, reboot. Does not return on success.
+void dp_prov_factory_reset(void);
+
+// MAC-derived stable UUID. Factory QR encodes the same value.
+esp_err_t dp_prov_get_dev_uuid(uint8_t out[DP_PROV_UUID_LEN]);
+
+#ifdef __cplusplus
+}
+#endif

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,32 +58,46 @@ port that ships in the same IDF tree. Reasons are documented in
     packed `berth_diag_t` (segmented). Opt-in, gated by
     `CONFIG_DOCKPULSE_DIAG_ENABLE`.
 
-### Self-provisioning
+### PB-ADV provisioning
 
-Every node runs as a single-device PROVISIONER and self-configures via
-the local-data API. There is **no on-air provisioning handshake** —
-every node is hard-coded with the same NetKey, AppKey, and a
-deterministic unicast address derived from `CONFIG_DOCKPULSE_NODE_ID`:
+Sensor = NODE, gateway = PROVISIONER. Real PB-ADV handshake; on-air keys
++ unicast address are assigned by the gateway during adoption.
 
-| Role    | NODE_ID | Unicast addr |
-| ------- | ------- | ------------ |
-| Gateway | 1       | `0x0001`     |
-| Sensor  | N       | `0x0001 + N` |
+Adoption flow:
 
-The gateway pre-registers a phantom entry for every possible sensor
-address (`0x0002..0x0009`, configurable via `DP_MAX_SENSORS` in
-`dp_mesh.c`); each sensor pre-registers the gateway. This bypasses the
-`esp_ble_mesh` provisioner's source-address filter that would otherwise
-drop all peer traffic — see
-[troubleshooting.md](troubleshooting.md#provisioner-src-address-filter)
-for the deep dive on why this is needed.
+1. Operator scans the sensor's QR sticker in the dashboard. QR carries a
+   factory-signed claim JWT with `uuid`, `oob`, `serial_number`.
+2. Backend verifies the JWT, picks a target gateway + berth, publishes
+   `dockpulse/v1/gw/{gw_id}/provision/req` (qos 1, retained=false) with
+   `{req_id, uuid, oob, ttl_s, berth_id}`.
+3. Gateway sets the OOB value, filters scan beacons by UUID, runs
+   PB-ADV against the matching unprov sensor. Stack auto-allocates the
+   next free unicast in the gateway's `prov_start_address` range.
+4. Gateway pushes AppKey Add → Model App Bind → Model Pub Set via cfg
+   client to the new node, retrieves its DevKey, then publishes
+   `dockpulse/v1/gw/{gw_id}/provision/resp` with
+   `{req_id, status: "ok", unicast_addr, dev_key_fp}` (sha256(dev_key)
+   first 8 bytes hex). Errors yield `{status: "err", code, msg}`.
+5. Backend writes a `Node` row keyed on `unicast_addr` + `berth_id`.
+   Gateway records the same mapping locally in dp_prov NVS; uplink
+   uses it to render the MQTT topic.
 
-This is deliberately not a production-grade design: shared static keys,
-no auth, hardcoded address range, reliance on an internal API
-(`bt_mesh_provisioner_provision`). It is appropriate for the course
-prototype; replace with standard PB-ADV provisioning before any real
-deployment. See [troubleshooting.md](troubleshooting.md#standard-vs-self-provisioning)
-for the migration sketch.
+Gateway online/offline state: gateway publishes
+`dockpulse/v1/gw/{gw_id}/status` retained `{online: true}` on connect,
+LWT publishes `{online: false}` on disconnect.
+
+Hot-swap: re-running step 1 with a new sensor on a berth that already
+has a Node row replaces the gateway's old `unicast -> berth` mapping in
+dp_prov; the new node takes over publishing. Backend Node row is
+similarly replaced (server-side ticket).
+
+Factory reset: 5-second long-press on GPIO 9 wipes both dp_prov and
+the BLE Mesh stack NVS, then reboots into PB-ADV unprov mode.
+
+Bench / two-board testing: when no real backend is around, ship-time
+`CONFIG_DOCKPULSE_NODE_ID` still works as a payload `node_id` and
+fallback berth-id index — bring up gateway + sensor, leave gateway in
+`UPLINK_STUB=y` to skip MQTT.
 
 ## Wire format
 
@@ -216,27 +230,17 @@ routine operation.
 
 ```
 main/                 role dispatch + per-role event loops
-  app_main.c          NVS init + role select
-  sensor_main.c       sensor loop: radar read → publish
+  app_main.c          NVS init + LED/button + role select
+  sensor_main.c       sensor loop: radar read → publish (gated on adoption)
   gateway_main.c      gateway loop: rx callback → uplink
 
-components/dp_common  shared types and codec
-  dp_common.h         dp_radar_sample_t, berth_status_t,
-                      pack/unpack helpers
-  dp_common.c         CONFIG_DOCKPULSE_NODE_ID accessor + codec impl
-
+components/dp_common  shared types + codec
 components/dp_radar   Waveshare HMMD UART driver
-  dp_radar.c          frame parser, mode-change command, ACK parsing,
-                      fake-radar mode behind CONFIG_DOCKPULSE_RADAR_FAKE
-
-components/dp_mesh    esp_ble_mesh wrapper
-  dp_mesh.c           NimBLE host bringup, vendor model registration,
-                      self-provisioning, phantom-peer registration
-
-components/dp_gateway uplink (Wi-Fi STA + MQTT)
-  dp_gateway.c        berth_status_t → JSON, topic mapping
-  dp_gateway_wifi.c   Wi-Fi station bringup
-  dp_gateway_mqtt.c   MQTT client + QoS handling
+components/dp_mesh    esp_ble_mesh wrapper, PB-ADV adoption
+components/dp_prov    NVS unicast→berth_id map + factory reset
+components/dp_io      LED state machine + factory-reset button
+components/dp_gateway Wi-Fi + MQTT, MQTT adoption topics
+  dp_gateway_adopt.c  provision/req → mesh provision → provision/resp
 ```
 
 ## Sensor periodicity

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -11,5 +11,5 @@ endif()
 idf_component_register(
     SRCS ${srcs}
     INCLUDE_DIRS "."
-    REQUIRES dp_common dp_mesh dp_radar dp_gateway nvs_flash
+    REQUIRES dp_common dp_mesh dp_radar dp_gateway dp_prov dp_io nvs_flash
 )

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -28,11 +28,21 @@ menu "DockPulse"
         int "Status LED GPIO (-1 to disable)"
         default 8
         help
-            ESP32-C3 SuperMini onboard LED is GPIO 8 (active-low).
+            Waveshare ESP32-C3-Zero onboard WS2812 RGB is GPIO 8.
+            Plain LED on a C3 SuperMini is also GPIO 8 (active-low).
+
+    config DOCKPULSE_LED_WS2812
+        bool "LED is WS2812 (addressable RGB)"
+        default y
+        help
+            Drive via led_strip RMT, map states to colors (green=ok,
+            blue=provisioning, red=error). Off = plain GPIO via
+            gpio_set_level.
 
     config DOCKPULSE_LED_ACTIVE_LOW
-        bool "LED is active-low"
+        bool "Plain-LED active-low (ignored when WS2812)"
         default y
+        depends on !DOCKPULSE_LED_WS2812
 
     config DOCKPULSE_FACTORY_RESET_GPIO
         int "Factory-reset button GPIO (-1 to disable)"

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -15,13 +15,35 @@ menu "DockPulse"
     endchoice
 
     config DOCKPULSE_NODE_ID
-        int "Node ID (unique within installation)"
+        int "Node ID (legacy/bench fallback)"
         range 1 8
         default 1
         help
-            Sensor unicast addr = 0x0001 + NODE_ID. Gateway pre-registers
-            DP_MAX_SENSORS (8) sensor slots; raise both together if you
-            need more nodes.
+            Sensor `node_id` payload field + bench-mode berth-id index
+            (1..12 -> t1..t4 / l1..l4 / r1..r4). After QR provisioning
+            the unicast addr is assigned by PB-ADV and the berth id
+            comes from the gateway dp_prov table.
+
+    config DOCKPULSE_LED_GPIO
+        int "Status LED GPIO (-1 to disable)"
+        default 8
+        help
+            ESP32-C3 SuperMini onboard LED is GPIO 8 (active-low).
+
+    config DOCKPULSE_LED_ACTIVE_LOW
+        bool "LED is active-low"
+        default y
+
+    config DOCKPULSE_FACTORY_RESET_GPIO
+        int "Factory-reset button GPIO (-1 to disable)"
+        default 9
+        help
+            GPIO 9 = BOOT button on most C3 devkits. Long-press at
+            runtime; doesn't collide with bootloader strap.
+
+    config DOCKPULSE_FACTORY_RESET_HOLD_MS
+        int "Long-press hold time (ms)"
+        default 5000
 
     menu "Sensor"
         depends on DOCKPULSE_ROLE_SENSOR
@@ -162,6 +184,16 @@ menu "DockPulse"
             default "dock-a"
             help
                 Used as the {dock_id} segment of the MQTT topic.
+
+        config DOCKPULSE_GATEWAY_ID
+            string "Gateway ID (adoption topic segment)"
+            depends on !DOCKPULSE_GATEWAY_UPLINK_STUB
+            default "gw-001"
+            help
+                Used in dockpulse/v1/gw/{gw_id}/{...} topics for the
+                adoption protocol (provision/req, provision/resp,
+                status). Must match a row in the backend's gateways
+                table; the backend rejects requests for unknown ids.
 
         config DOCKPULSE_BERTH_ID_FORMAT
             string "Berth ID format (printf %s = suffix)"

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -2,6 +2,9 @@
 #include "nvs_flash.h"
 #include "sdkconfig.h"
 
+#include "dp_io.h"
+#include "dp_prov.h"
+
 static const char *TAG = "dockpulse";
 
 #if CONFIG_DOCKPULSE_ROLE_SENSOR
@@ -21,15 +24,26 @@ static void init_nvs(void)
     ESP_ERROR_CHECK(err);
 }
 
+static void on_factory_reset(void *ctx)
+{
+    (void)ctx;
+    dp_led_set(DP_LED_ERROR);
+    dp_prov_factory_reset();
+}
+
 void app_main(void)
 {
     init_nvs();
+    dp_prov_init();
+    dp_led_init();
+    dp_button_init(on_factory_reset, NULL);
+    dp_led_set(DP_LED_IDLE);
 
 #if CONFIG_DOCKPULSE_ROLE_SENSOR
-    ESP_LOGI(TAG, "boot: role=sensor node=%d", CONFIG_DOCKPULSE_NODE_ID);
+    ESP_LOGI(TAG, "boot: role=sensor");
     dp_sensor_run();
 #elif CONFIG_DOCKPULSE_ROLE_GATEWAY
-    ESP_LOGI(TAG, "boot: role=gateway node=%d", CONFIG_DOCKPULSE_NODE_ID);
+    ESP_LOGI(TAG, "boot: role=gateway");
     dp_gateway_run();
 #else
 #error "Select DOCKPULSE_ROLE via menuconfig"

--- a/main/gateway_main.c
+++ b/main/gateway_main.c
@@ -5,6 +5,7 @@
 
 #include "dp_common.h"
 #include "dp_gateway.h"
+#include "dp_io.h"
 #include "dp_mesh.h"
 
 static const char *TAG = "gateway";
@@ -31,6 +32,7 @@ void dp_gateway_run(void)
         .status_cb = on_status,
         .diag_cb = on_diag,
     }));
+    dp_led_set(DP_LED_OK);
 
     while (true) {
         vTaskDelay(pdMS_TO_TICKS(10000));

--- a/main/sensor_main.c
+++ b/main/sensor_main.c
@@ -5,34 +5,43 @@
 #include "sdkconfig.h"
 
 #include "dp_common.h"
+#include "dp_io.h"
 #include "dp_mesh.h"
 #include "dp_radar.h"
 #include "dp_radar_filter.h"
 
 static const char *TAG = "sensor";
 
-static berth_status_t to_status(const dp_radar_sample_t *s, bool occupied, uint8_t node_id)
+static volatile bool s_mesh_ready;
+static volatile uint16_t s_unicast;
+
+static void on_sensor_ready(uint16_t addr)
+{
+    s_unicast = addr;
+    s_mesh_ready = true;
+    dp_led_set(DP_LED_OK);
+    ESP_LOGI(TAG, "mesh ready addr=0x%04x", addr);
+}
+
+static berth_status_t to_status(const dp_radar_sample_t *s, bool occupied, uint8_t node_id,
+                                uint16_t berth_id)
 {
     return (berth_status_t){
         .node_id = node_id,
-        // 1:1 sensor-to-berth mapping for now. When that changes,
-        // route node_id → berth_id through a config lookup here
-        .berth_id = node_id,
+        .berth_id = berth_id,
         .occupied = occupied,
         .sensor_raw_mm = (uint16_t)(s->distance_cm * 10u),
-        // Battery monitoring not yet wired (no ADC divider on the
-        // current hardware revision)
         .battery_pct = DP_BATTERY_UNKNOWN,
         .ts_ms = s->ts_ms,
     };
 }
 
 #if CONFIG_DOCKPULSE_DIAG_ENABLE
-static berth_diag_t to_diag(const dp_radar_sample_t *s, uint8_t node_id)
+static berth_diag_t to_diag(const dp_radar_sample_t *s, uint8_t node_id, uint16_t berth_id)
 {
     berth_diag_t d = {
         .node_id = node_id,
-        .berth_id = node_id,
+        .berth_id = berth_id,
         .target_state = s->target_state,
         .raw_distance_cm = s->distance_cm,
         .ts_ms = s->ts_ms,
@@ -47,45 +56,32 @@ static berth_diag_t to_diag(const dp_radar_sample_t *s, uint8_t node_id)
 void dp_sensor_run(void)
 {
     ESP_ERROR_CHECK(dp_radar_init());
-    ESP_ERROR_CHECK(dp_mesh_init(&(const dp_mesh_cfg_t){.role = DP_MESH_ROLE_SENSOR}));
 
-    uint8_t node_id = 0;
-    dp_common_get_node_id(&node_id);
+    dp_led_set(DP_LED_PROVISIONING);
+    ESP_ERROR_CHECK(dp_mesh_init(&(const dp_mesh_cfg_t){
+        .role = DP_MESH_ROLE_SENSOR,
+        .sensor_ready = on_sensor_ready,
+    }));
 
-    // The HMMD streams Report frames at ~10 Hz. If we sleep longer than
-    // the UART RX buffer can hold (~140 ms at 115200 baud), the buffer
-    // ages out into mid-frame garbage and reads time out. So we *read*
-    // at the radar's natural cadence and only *publish* on the slower
-    // CONFIG_DOCKPULSE_SENSOR_PERIOD_MS schedule.
-    //
-    // TODO: replace this poll-and-throttle pattern with deep-sleep +
-    // OT2 GPIO wakeup once we tackle the solar power budget. Currently
-    // CPU runs continuously which is fine for mains-powered bench
-    // testing
+    uint8_t node_id = (uint8_t)CONFIG_DOCKPULSE_NODE_ID;
+
+    // HMMD streams Report at ~10Hz; UART RX buffer ages into garbage if
+    // we sleep > ~140ms. Read at radar cadence, publish on slower
+    // CONFIG_DOCKPULSE_SENSOR_PERIOD_MS.
     const TickType_t read_interval = pdMS_TO_TICKS(200);
     const TickType_t publish_interval = pdMS_TO_TICKS(CONFIG_DOCKPULSE_SENSOR_PERIOD_MS);
     TickType_t last_publish = 0;
 
-    // The HMMD occasionally drops out of Report mode (silent, no error
-    // surfaces). After this many back-to-back read timeouts, we nudge
-    // it back by re-sending the mode-change command. Worst case per
-    // miss is ~700 ms (500 ms read timeout + 200 ms gap), so 10 misses
-    // ≈ 7 s — long enough to skip the radar's own brief calibration
-    // pauses without false-positive recovery
     const int RECOVERY_THRESHOLD = 10;
     int consecutive_failures = 0;
 
     while (true) {
-        // 500ms is plenty: HMMD streams at ~10Hz, so a fresh frame
-        // should arrive within 100ms. The radar occasionally pauses
-        // for one or two frames (calibration), which is normal — log
-        // at DEBUG so the warning isn't noisy in steady state
         dp_radar_sample_t s;
         esp_err_t err = dp_radar_read(&s, pdMS_TO_TICKS(500));
         if (err != ESP_OK) {
-            ESP_LOGD(TAG, "radar read skipped: %s", esp_err_to_name(err));
+            ESP_LOGD(TAG, "radar skip: %s", esp_err_to_name(err));
             if (++consecutive_failures == RECOVERY_THRESHOLD) {
-                ESP_LOGW(TAG, "no radar frames in %dx reads — re-sending mode-change",
+                ESP_LOGW(TAG, "no radar frames in %dx — re-sending mode-change",
                          RECOVERY_THRESHOLD);
                 dp_radar_enter_report_mode();
                 consecutive_failures = 0;
@@ -95,18 +91,13 @@ void dp_sensor_run(void)
         }
         consecutive_failures = 0;
 
-        // Evaluate every read so the proximity stability window sees
-        // a continuous frame stream, not the sparse one
-        // CONFIG_DOCKPULSE_SENSOR_PERIOD_MS would give
         bool near = dp_radar_filter_near(&s);
 
         TickType_t now = xTaskGetTickCount();
         if (last_publish == 0 || (now - last_publish) >= publish_interval) {
             ESP_LOGI(TAG, "presence=%d distance_cm=%u near=%d", s.presence, s.distance_cm,
                      (int)near);
-            // Field-test trace: one CSV-style line per published sample
-            // so logs can be grepped (`grep ',RADAR,' …`) and fed to a
-            // plotter to set per-berth gate thresholds
+            // CSV trace for grep + plotter (per-berth gate threshold tuning)
             ESP_LOGI(TAG,
                      "RADAR,%u,%d,%u,"
                      "%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u",
@@ -116,12 +107,18 @@ void dp_sensor_run(void)
                      s.gate_energy[9], s.gate_energy[10], s.gate_energy[11], s.gate_energy[12],
                      s.gate_energy[13], s.gate_energy[14], s.gate_energy[15]);
 
-            berth_status_t status = to_status(&s, near, node_id);
-            dp_mesh_publish_status(&status);
+            if (s_mesh_ready) {
+                // berth_id field is informational (gateway prefers its
+                // unicast->berth lookup); send NODE_ID as bench fallback
+                berth_status_t status = to_status(&s, near, node_id, node_id);
+                dp_mesh_publish_status(&status);
 #if CONFIG_DOCKPULSE_DIAG_ENABLE
-            berth_diag_t diag = to_diag(&s, node_id);
-            dp_mesh_publish_diag(&diag);
+                berth_diag_t diag = to_diag(&s, node_id, node_id);
+                dp_mesh_publish_diag(&diag);
 #endif
+            } else {
+                ESP_LOGD(TAG, "skip publish — not adopted");
+            }
             last_publish = now;
         }
 

--- a/main/sensor_main.c
+++ b/main/sensor_main.c
@@ -55,13 +55,18 @@ static berth_diag_t to_diag(const dp_radar_sample_t *s, uint8_t node_id, uint16_
 
 void dp_sensor_run(void)
 {
-    ESP_ERROR_CHECK(dp_radar_init());
-
     dp_led_set(DP_LED_PROVISIONING);
     ESP_ERROR_CHECK(dp_mesh_init(&(const dp_mesh_cfg_t){
         .role = DP_MESH_ROLE_SENSOR,
         .sensor_ready = on_sensor_ready,
     }));
+
+    // defer radar until adopted saves UART power and log noise
+    while (!s_mesh_ready) {
+        vTaskDelay(pdMS_TO_TICKS(500));
+    }
+    ESP_LOGI(TAG, "adopted — bringing up radar");
+    ESP_ERROR_CHECK(dp_radar_init());
 
     uint8_t node_id = (uint8_t)CONFIG_DOCKPULSE_NODE_ID;
 
@@ -107,18 +112,13 @@ void dp_sensor_run(void)
                      s.gate_energy[9], s.gate_energy[10], s.gate_energy[11], s.gate_energy[12],
                      s.gate_energy[13], s.gate_energy[14], s.gate_energy[15]);
 
-            if (s_mesh_ready) {
-                // berth_id field is informational (gateway prefers its
-                // unicast->berth lookup); send NODE_ID as bench fallback
-                berth_status_t status = to_status(&s, near, node_id, node_id);
-                dp_mesh_publish_status(&status);
+            // berth_id is just a hint gateway uses its unicast->berth lookup
+            berth_status_t status = to_status(&s, near, node_id, node_id);
+            dp_mesh_publish_status(&status);
 #if CONFIG_DOCKPULSE_DIAG_ENABLE
-                berth_diag_t diag = to_diag(&s, node_id, node_id);
-                dp_mesh_publish_diag(&diag);
+            berth_diag_t diag = to_diag(&s, node_id, node_id);
+            dp_mesh_publish_diag(&diag);
 #endif
-            } else {
-                ESP_LOGD(TAG, "skip publish — not adopted");
-            }
             last_publish = now;
         }
 

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -18,6 +18,10 @@ CONFIG_BLE_MESH=y
 CONFIG_BLE_MESH_NODE=y
 CONFIG_BLE_MESH_PROVISIONER=y
 CONFIG_BLE_MESH_PB_ADV=y
+# cfg client used by gateway to push AppKey + Model App Bind + Model Pub Set
+# to a freshly provisioned sensor. Linked on sensor too (unused there) so a
+# single image config covers both roles.
+CONFIG_BLE_MESH_CFG_CLI=y
 # CONFIG_BLE_MESH_PB_GATT is not set
 # CONFIG_BLE_MESH_GATT_PROXY_SERVER is not set
 CONFIG_BLE_MESH_RELAY=y

--- a/tools/sim-adopt.sh
+++ b/tools/sim-adopt.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Bench-test helper for QR adoption: composes the sensor's mesh UUID
+# from its MAC, the placeholder static OOB from dp_mesh.c, and emits
+# a fake `dockpulse/v1/gw/{gw_id}/provision/req` to a local mosquitto.
+#
+# Usage:
+#   tools/sim-adopt.sh -m AABBCCDDEEFF -b ksss-saltsjobaden-pier-1-t1
+#   tools/sim-adopt.sh -m AA:BB:CC:DD:EE:FF -g gw-001 -h 127.0.0.1
+#
+# MAC comes from the sensor's boot log — look for a line like
+#   I (1234) dp_mesh: ready role=sensor uuid=aabbccddeeff444f434b50554c534501
+# the first 12 hex chars (6 bytes) are the MAC; everything after is the
+# 'DOCKPULSE' marker the firmware appends.
+#
+# Listens for the gateway's reply on dockpulse/v1/gw/{gw_id}/provision/resp
+# for up to 65 seconds before giving up.
+
+set -euo pipefail
+
+print_help() { sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; }
+
+MAC=""
+BERTH=""
+GW_ID="gw-001"
+HOST="127.0.0.1"
+PORT="1883"
+REQ_ID="bench-$(date +%s)"
+TTL_S=60
+# placeholder static OOB from components/dp_mesh/dp_mesh.c — must
+# match what the gateway pushes via set_static_oob_value
+OOB_HEX="64702d7374617469632d6f6f62000000"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -m|--mac|-u|--uuid) MAC="$2"; shift 2 ;;
+        -b|--berth)         BERTH="$2"; shift 2 ;;
+        -g|--gateway-id)    GW_ID="$2"; shift 2 ;;
+        -h|--host)          HOST="$2"; shift 2 ;;
+        --port)             PORT="$2"; shift 2 ;;
+        --req-id)           REQ_ID="$2"; shift 2 ;;
+        --ttl)              TTL_S="$2"; shift 2 ;;
+        --oob)              OOB_HEX="$2"; shift 2 ;;
+        --help)             print_help; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+[[ -n "$MAC" ]] || { echo "missing -m MAC (12 hex) or -u UUID (32 hex)" >&2; exit 2; }
+[[ -n "$BERTH" ]] || { echo "missing -b BERTH_ID" >&2; exit 2; }
+
+# normalise: strip colons/dashes/spaces, lowercase
+HEX=$(printf '%s' "$MAC" | tr -d ':-' | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+MARKER_HEX="444f434b50554c5345"  # 'DOCKPULSE'
+case ${#HEX} in
+    12) UUID_HEX="${HEX}${MARKER_HEX}01" ;;  # bare MAC -> append marker
+    32) UUID_HEX="$HEX" ;;                    # full UUID -> use as-is
+    *)  echo "expected 12 hex (MAC) or 32 hex (UUID), got ${#HEX}: '$HEX'" >&2; exit 2 ;;
+esac
+
+REQ_TOPIC="dockpulse/v1/gw/${GW_ID}/provision/req"
+RESP_TOPIC="dockpulse/v1/gw/${GW_ID}/provision/resp"
+
+PAYLOAD=$(cat <<EOF
+{"req_id":"${REQ_ID}","uuid":"${UUID_HEX}","oob":"${OOB_HEX}","ttl_s":${TTL_S},"berth_id":"${BERTH}"}
+EOF
+)
+
+echo "publish to ${HOST}:${PORT} ${REQ_TOPIC}"
+echo "  payload: ${PAYLOAD}"
+mosquitto_pub -h "$HOST" -p "$PORT" -t "$REQ_TOPIC" -m "$PAYLOAD" -q 1
+
+echo
+echo "waiting on ${RESP_TOPIC} (timeout $((TTL_S + 5))s)..."
+# -C 1 = exit after one matching message; -W = timeout wrapper
+mosquitto_sub -h "$HOST" -p "$PORT" -t "$RESP_TOPIC" -W $((TTL_S + 5)) -C 1

--- a/tools/sim-adopt.sh
+++ b/tools/sim-adopt.sh
@@ -1,19 +1,14 @@
 #!/usr/bin/env bash
-# Bench-test helper for QR adoption: composes the sensor's mesh UUID
-# from its MAC, the placeholder static OOB from dp_mesh.c, and emits
-# a fake `dockpulse/v1/gw/{gw_id}/provision/req` to a local mosquitto.
+# bench helper for QR adoption. composes mesh UUID from MAC pushes a
+# fake provision/req to local mosquitto waits for resp
 #
-# Usage:
+# usage:
 #   tools/sim-adopt.sh -m AABBCCDDEEFF -b ksss-saltsjobaden-pier-1-t1
-#   tools/sim-adopt.sh -m AA:BB:CC:DD:EE:FF -g gw-001 -h 127.0.0.1
+#   tools/sim-adopt.sh -u <full-32-hex-uuid> -g gw-001 -h 127.0.0.1
 #
-# MAC comes from the sensor's boot log — look for a line like
+# MAC or full UUID comes from sensor boot log line:
 #   I (1234) dp_mesh: ready role=sensor uuid=aabbccddeeff444f434b50554c534501
-# the first 12 hex chars (6 bytes) are the MAC; everything after is the
-# 'DOCKPULSE' marker the firmware appends.
-#
-# Listens for the gateway's reply on dockpulse/v1/gw/{gw_id}/provision/resp
-# for up to 65 seconds before giving up.
+# first 12 hex = MAC rest = DOCKPULSE marker firmware appends
 
 set -euo pipefail
 
@@ -26,8 +21,7 @@ HOST="127.0.0.1"
 PORT="1883"
 REQ_ID="bench-$(date +%s)"
 TTL_S=60
-# placeholder static OOB from components/dp_mesh/dp_mesh.c — must
-# match what the gateway pushes via set_static_oob_value
+# placeholder OOB from dp_mesh.c must match gateway set_static_oob_value
 OOB_HEX="64702d7374617469632d6f6f62000000"
 
 while [[ $# -gt 0 ]]; do
@@ -48,13 +42,13 @@ done
 [[ -n "$MAC" ]] || { echo "missing -m MAC (12 hex) or -u UUID (32 hex)" >&2; exit 2; }
 [[ -n "$BERTH" ]] || { echo "missing -b BERTH_ID" >&2; exit 2; }
 
-# normalise: strip colons/dashes/spaces, lowercase
+# strip colons dashes spaces lowercase
 HEX=$(printf '%s' "$MAC" | tr -d ':-' | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
-MARKER_HEX="444f434b50554c5345"  # 'DOCKPULSE'
+MARKER_HEX="444f434b50554c5345"  # DOCKPULSE
 case ${#HEX} in
-    12) UUID_HEX="${HEX}${MARKER_HEX}01" ;;  # bare MAC -> append marker
-    32) UUID_HEX="$HEX" ;;                    # full UUID -> use as-is
-    *)  echo "expected 12 hex (MAC) or 32 hex (UUID), got ${#HEX}: '$HEX'" >&2; exit 2 ;;
+    12) UUID_HEX="${HEX}${MARKER_HEX}01" ;;  # bare MAC append marker
+    32) UUID_HEX="$HEX" ;;                    # full UUID use as-is
+    *)  echo "expected 12 hex (MAC) or 32 hex (UUID) got ${#HEX}: '$HEX'" >&2; exit 2 ;;
 esac
 
 REQ_TOPIC="dockpulse/v1/gw/${GW_ID}/provision/req"
@@ -71,5 +65,5 @@ mosquitto_pub -h "$HOST" -p "$PORT" -t "$REQ_TOPIC" -m "$PAYLOAD" -q 1
 
 echo
 echo "waiting on ${RESP_TOPIC} (timeout $((TTL_S + 5))s)..."
-# -C 1 = exit after one matching message; -W = timeout wrapper
+# -C 1 exit after first match -W timeout wrapper
 mosquitto_sub -h "$HOST" -p "$PORT" -t "$RESP_TOPIC" -W $((TTL_S + 5)) -C 1


### PR DESCRIPTION
## Summary

Replaces shared-keys + deterministic-unicast self-provisioning hack with real PB-ADV adoption. Sensors boot into inprov mode on first power-on or after factory reset.

## Related Issue

Closes #21
Closes #22

## Checklist

- [x] Code compiles/builds without errors or warnings
- [x] Code follows the project style guide and has been formatted
- [x] All existing tests pass
- [ ] New functionality includes appropriate tests
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format

## Backend notes

This PR assumes a small backend extension: `provision/req` payload Should carry the assigned `berth_id` so the gateway can render the right MQTT uplink topic.

## Known follow-ups

- Factory state OOB in `db_mesh.c` is a placeholder, production needs a per-device value in the QR claim.
- No automated tests for the adoption path.
